### PR TITLE
impl Display instead of to_string directly

### DIFF
--- a/orange-sdk/src/ffi/ldk_node.rs
+++ b/orange-sdk/src/ffi/ldk_node.rs
@@ -37,9 +37,11 @@ impl Mnemonic {
 			Err(_) => Err(ConfigError::InvalidMnemonic),
 		}
 	}
+}
 
-	pub fn to_string(&self) -> String {
-		self.0.to_string()
+impl std::fmt::Display for Mnemonic {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		write!(f, "{}", self.0)
 	}
 }
 


### PR DESCRIPTION
Fixes #18 by implementing `Display` for `Mnemonic`