### PR TITLE
Rework GraduatedRebalancer to work across restarts

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ panic = 'abort'     # Abort on panic
 bitcoin-payment-instructions = { version = "0.6.0" }
 lightning = { version = "0.2.0" }
 lightning-invoice = { version = "0.34.0" }
+lightning-macros = "0.2.0"
 
 [profile.release]
 panic = "abort"

--- a/examples/cli/src/main.rs
+++ b/examples/cli/src/main.rs
@@ -4,6 +4,7 @@ use colored::Colorize;
 use rustyline::DefaultEditor;
 use rustyline::error::ReadlineError;
 
+use orange_sdk::bitcoin::hex::DisplayHex;
 use orange_sdk::bitcoin_payment_instructions::amount::Amount;
 use orange_sdk::{
 	CashuConfig, ChainSource, CurrencyUnit, Event, ExtraConfig, LoggerType, Mnemonic, PaymentInfo,
@@ -226,6 +227,21 @@ impl WalletState {
 								"✅".bright_green(),
 								amount_msat,
 								fee_msat
+							);
+						},
+						Event::RebalanceFailed {
+							trigger_payment_id,
+							trusted_rebalance_payment_id,
+							amount_msat,
+							reason,
+						} => {
+							println!(
+								"{} Rebalance failed: {} msat, trigger_payment_id: {}, trusted_rebalance_payment_id: {:?}, reason: {}",
+								"❌".bright_red(),
+								amount_msat,
+								trigger_payment_id,
+								trusted_rebalance_payment_id.map(|id| id.to_lower_hex_string()),
+								reason
 							);
 						},
 						Event::SplicePending { new_funding_txo, .. } => {

--- a/graduated-rebalancer/Cargo.toml
+++ b/graduated-rebalancer/Cargo.toml
@@ -10,4 +10,5 @@ license = "MIT OR Apache-2.0"
 bitcoin-payment-instructions = { workspace = true }
 lightning = { workspace = true }
 lightning-invoice = { workspace = true }
-tokio = { version = "1", default-features = false }
+lightning-macros = { workspace = true }
+tokio = { version = "1", default-features = false, features = ["sync", "macros"] }

--- a/graduated-rebalancer/Cargo.toml
+++ b/graduated-rebalancer/Cargo.toml
@@ -11,4 +11,4 @@ bitcoin-payment-instructions = { workspace = true }
 lightning = { workspace = true }
 lightning-invoice = { workspace = true }
 lightning-macros = { workspace = true }
-tokio = { version = "1", default-features = false, features = ["sync", "macros"] }
+tokio = { version = "1", default-features = false, features = ["sync", "macros", "rt", "time"] }

--- a/graduated-rebalancer/src/lib.rs
+++ b/graduated-rebalancer/src/lib.rs
@@ -12,13 +12,119 @@ use bitcoin_payment_instructions::PaymentMethod;
 use lightning::bitcoin::hashes::Hash;
 use lightning::bitcoin::hex::DisplayHex;
 use lightning::bitcoin::OutPoint;
+use lightning::impl_writeable_tlv_based;
 use lightning::util::logger::Logger;
 use lightning::{log_debug, log_error, log_info};
 use lightning_invoice::Bolt11Invoice;
+
 use std::fmt::Debug;
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
+
+/// Represents the state of an in-progress rebalance from trusted to lightning wallet
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RebalanceState {
+	/// ID from the rebalance trigger
+	pub trigger_id: [u8; 32],
+	/// Expected payment hash for the lightning invoice
+	pub expected_payment_hash: [u8; 32],
+	/// Amount being rebalanced in millisatoshis
+	pub amount_msat: u64,
+	/// Whether the lightning wallet has received the payment
+	pub ln_payment_received: bool,
+	/// Whether the trusted wallet has confirmed sending the payment
+	pub trusted_payment_sent: bool,
+	/// Payment ID from the trusted wallet
+	pub trusted_payment_id: Option<[u8; 32]>,
+	/// Lightning payment ID (set when received)
+	pub ln_payment_id: Option<[u8; 32]>,
+	/// Fee paid by lightning wallet in millisatoshis
+	pub ln_fee_msat: Option<u64>,
+	/// Fee paid by trusted wallet in millisatoshis
+	pub trusted_fee_msat: Option<u64>,
+}
+
+impl_writeable_tlv_based!(RebalanceState, {
+	(0, trigger_id, required),
+	(2, expected_payment_hash, required),
+	(4, amount_msat, required),
+	(6, ln_payment_received, required),
+	(8, trusted_payment_sent, required),
+	(10, trusted_payment_id, option),
+	(12, ln_payment_id, option),
+	(14, ln_fee_msat, option),
+	(16, trusted_fee_msat, option),
+});
+
+/// Represents the state of an in-progress on-chain rebalance
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct OnChainRebalanceState {
+	/// ID from the rebalance trigger (the triggering on-chain txid)
+	pub trigger_id: [u8; 32],
+	/// User channel ID assigned by LDK (set after operation completes)
+	pub user_channel_id: Option<u128>,
+	/// Amount being rebalanced in satoshis
+	pub amount_sats: u64,
+	/// Whether this is a splice (true) or channel open (false)
+	pub is_splice: bool,
+	/// Whether the channel/splice pending event has been received
+	pub pending_confirmed: bool,
+	/// The channel outpoint (set when pending_confirmed is true)
+	pub channel_outpoint: Option<OutPoint>,
+}
+
+impl_writeable_tlv_based!(OnChainRebalanceState, {
+	(0, trigger_id, required),
+	(2, user_channel_id, option),
+	(4, amount_sats, required),
+	(6, is_splice, required),
+	(8, pending_confirmed, required),
+	(10, channel_outpoint, option),
+});
+
+/// Trait for persisting rebalance state across restarts
+pub trait RebalancePersistence: Send + Sync {
+	/// Insert a new trusted rebalance state
+	fn insert_trusted_rebalance_state(
+		&self, state: RebalanceState,
+	) -> Pin<Box<dyn Future<Output = ()> + Send + '_>>;
+
+	/// Update an existing trusted rebalance state
+	fn update_trusted_rebalance_state(
+		&self, state: RebalanceState,
+	) -> Pin<Box<dyn Future<Output = ()> + Send + '_>> {
+		self.insert_trusted_rebalance_state(state)
+	}
+
+	/// Remove a trusted rebalance state
+	fn remove_trusted_rebalance_state(&self) -> Pin<Box<dyn Future<Output = ()> + Send + '_>>;
+
+	/// Gets the current trusted rebalance state
+	fn get_trusted_rebalance(
+		&self,
+	) -> Pin<Box<dyn Future<Output = Result<Option<RebalanceState>, ()>> + Send + '_>>;
+
+	/// Insert a new on-chain rebalance state
+	fn insert_onchain_rebalance_state(
+		&self, state: OnChainRebalanceState,
+	) -> Pin<Box<dyn Future<Output = ()> + Send + '_>>;
+
+	/// Update an existing on-chain rebalance state
+	fn update_onchain_rebalance_state(
+		&self, state: OnChainRebalanceState,
+	) -> Pin<Box<dyn Future<Output = ()> + Send + '_>> {
+		self.insert_onchain_rebalance_state(state)
+	}
+
+	/// Remove an on-chain rebalance state
+	fn remove_onchain_rebalance_state(&self) -> Pin<Box<dyn Future<Output = ()> + Send + '_>>;
+
+	/// Gets the current on-chain rebalance state
+	fn get_onchain_rebalance(
+		&self,
+	) -> Pin<Box<dyn Future<Output = Result<Option<OnChainRebalanceState>, ()>> + Send + '_>>;
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 /// Parameters for doing a rebalance
@@ -60,6 +166,13 @@ impl Default for RebalanceTunables {
 	}
 }
 
+/// Information about a pending payment found in the trusted wallet
+#[derive(Debug, Clone, Copy)]
+pub struct PendingPaymentInfo {
+	/// The payment ID assigned by the trusted wallet
+	pub payment_id: [u8; 32],
+}
+
 /// Trait representing a trusted wallet backend
 pub trait TrustedWallet: Send + Sync {
 	/// Error type for trusted wallet operations
@@ -79,10 +192,13 @@ pub trait TrustedWallet: Send + Sync {
 		&self, method: PaymentMethod, amount: Amount,
 	) -> Pin<Box<dyn Future<Output = Result<[u8; 32], Self::Error>> + Send + '_>>;
 
-	/// Wait for a payment success notification
-	fn await_payment_success(
+	/// Find a pending outbound payment by its payment hash.
+	/// Returns `Some(PendingPaymentInfo)` if a pending payment with the given hash exists,
+	/// `None` otherwise. This is used during recovery to determine if a payment was
+	/// actually initiated before a crash.
+	fn find_payment_by_hash(
 		&self, payment_hash: [u8; 32],
-	) -> Pin<Box<dyn Future<Output = Option<ReceivedLightningPayment>> + Send + '_>>;
+	) -> Pin<Box<dyn Future<Output = Result<Option<PendingPaymentInfo>, Self::Error>> + Send + '_>>;
 }
 
 /// Trait representing a lightning wallet backend
@@ -103,11 +219,6 @@ pub trait LightningWallet: Send + Sync {
 		&self, method: PaymentMethod, amount: Amount,
 	) -> Pin<Box<dyn Future<Output = Result<[u8; 32], Self::Error>> + Send + '_>>;
 
-	/// Wait for a payment receipt notification
-	fn await_payment_receipt(
-		&self, payment_hash: [u8; 32],
-	) -> Pin<Box<dyn Future<Output = Option<ReceivedLightningPayment>> + Send + '_>>;
-
 	/// Check if we already have a channel with the LSP
 	fn has_channel_with_lsp(&self) -> bool;
 
@@ -116,29 +227,17 @@ pub trait LightningWallet: Send + Sync {
 		&self, amt: Amount,
 	) -> Pin<Box<dyn Future<Output = Result<u128, Self::Error>> + Send + '_>>;
 
-	/// Wait for a channel pending notification, returns the new channel's outpoint
-	fn await_channel_pending(
-		&self, channel_id: u128,
-	) -> Pin<Box<dyn Future<Output = OutPoint> + Send + '_>>;
-
 	/// Splice funds from on-chain to an existing channel with the LSP
 	fn splice_to_lsp_channel(
 		&self, amt: Amount,
 	) -> Pin<Box<dyn Future<Output = Result<u128, Self::Error>> + Send + '_>>;
 
-	/// Wait for a splice pending notification, returns the splice outpoint
-	fn await_splice_pending(
-		&self, channel_id: u128,
-	) -> Pin<Box<dyn Future<Output = OutPoint> + Send + '_>>;
-}
+	/// Get the funding outpoint for a channel by user_channel_id, if it exists
+	fn get_channel_outpoint(&self, user_channel_id: u128) -> Option<OutPoint>;
 
-/// Represents a payment from the lightning wallet
-#[derive(Debug, Clone)]
-pub struct ReceivedLightningPayment {
-	/// Unique payment ID
-	pub id: [u8; 32],
-	/// Fee paid in millisatoshis
-	pub fee_paid_msat: Option<u64>,
+	/// Find an untracked pending channel/splice with the LSP.
+	/// Returns None if no matching channel is found.
+	fn find_pending_lsp_channel(&self) -> Option<u128>;
 }
 
 /// Lightning wallet balance information
@@ -174,6 +273,17 @@ pub enum RebalancerEvent {
 		amount_msat: u64,
 		/// Total fee paid in millisatoshis
 		fee_msat: u64,
+	},
+	/// Rebalance failed
+	RebalanceFailed {
+		/// Trigger id given by the rebalance trigger
+		trigger_id: [u8; 32],
+		/// Trusted wallet payment ID for the rebalance
+		trusted_rebalance_payment_id: Option<[u8; 32]>,
+		/// Amount that was being rebalanced in millisatoshis
+		amount_msat: u64,
+		/// Reason for failure
+		reason: String,
 	},
 	/// We have initiated a lightning channel open
 	OnChainRebalanceInitiated {
@@ -212,37 +322,46 @@ pub struct GraduatedRebalancer<
 	L: LightningWallet,
 	R: RebalanceTrigger,
 	E: EventHandler,
+	P: RebalancePersistence,
 	O: Logger,
 > {
 	trusted: Arc<T>,
 	ln_wallet: Arc<L>,
 	trigger: Arc<R>,
 	event_handler: Arc<E>,
+	persistence: Arc<P>,
 	logger: Arc<O>,
 
-	/// Mutex to ensure thread-safe balance operations.
-	balance_mutex: tokio::sync::Mutex<()>,
+	/// In-memory cache of active rebalance (only one trusted rebalance allowed at a time)
+	active_trusted_rebalance: Arc<tokio::sync::Mutex<Option<RebalanceState>>>,
+
+	/// In-memory cache of active on-chain rebalance (only one on-chain rebalance allowed at a time)
+	active_onchain_rebalance: Arc<tokio::sync::Mutex<Option<OnChainRebalanceState>>>,
 }
 
-impl<T, LN, R, E, L> GraduatedRebalancer<T, LN, R, E, L>
+impl<T, LN, R, E, P, L> GraduatedRebalancer<T, LN, R, E, P, L>
 where
 	T: TrustedWallet,
 	LN: LightningWallet,
 	R: RebalanceTrigger,
 	E: EventHandler,
+	P: RebalancePersistence,
 	L: Logger,
 {
 	/// Create a new graduated rebalancer
 	pub fn new(
-		trusted: Arc<T>, ln_wallet: Arc<LN>, trigger: Arc<R>, event_handler: Arc<E>, logger: Arc<L>,
+		trusted: Arc<T>, ln_wallet: Arc<LN>, trigger: Arc<R>, event_handler: Arc<E>,
+		persistence: Arc<P>, logger: Arc<L>,
 	) -> Self {
 		Self {
 			trusted,
 			ln_wallet,
 			trigger,
 			event_handler,
+			persistence,
 			logger,
-			balance_mutex: tokio::sync::Mutex::new(()),
+			active_trusted_rebalance: Arc::new(tokio::sync::Mutex::new(None)),
+			active_onchain_rebalance: Arc::new(tokio::sync::Mutex::new(None)),
 		}
 	}
 
@@ -268,77 +387,80 @@ where
 	}
 
 	/// Perform a rebalance from trusted to lightning wallet
+	/// This method initiates the rebalance and returns immediately.
+	/// Completion is handled via the observer pattern (on_trusted_payment_sent, on_ln_payment_received).
 	async fn do_trusted_rebalance(&self, params: TriggerParams) {
-		let transfer_amt = params.amount;
-		let _lock = self.balance_mutex.lock().await;
+		// Check if there's already an active rebalance
+		let mut rebalance = self.active_trusted_rebalance.lock().await;
+		if rebalance.is_some() {
+			log_info!(self.logger, "Skipping rebalance trigger - already have an active rebalance");
+			return;
+		}
+
 		log_info!(self.logger, "Initiating rebalance");
 
+		let transfer_amt = params.amount;
 		if let Ok(inv) = self.ln_wallet.get_bolt11_invoice(Some(transfer_amt)).await {
 			log_debug!(
 				self.logger,
 				"Attempting to pay invoice {inv} to rebalance for {transfer_amt:?}",
 			);
-			let expected_hash = *inv.payment_hash();
+
+			let expected_hash = inv.payment_hash().to_byte_array();
+
+			// Create and persist rebalance state
+			let mut state = RebalanceState {
+				trigger_id: params.id,
+				expected_payment_hash: expected_hash,
+				amount_msat: transfer_amt.milli_sats(),
+				ln_payment_received: false,
+				trusted_payment_sent: false,
+				trusted_payment_id: None,
+				ln_payment_id: None,
+				ln_fee_msat: None,
+				trusted_fee_msat: None,
+			};
+			self.persistence.insert_trusted_rebalance_state(state).await;
+
 			match self.trusted.pay(PaymentMethod::LightningBolt11(inv), transfer_amt).await {
-				Ok(rebalance_id) => {
+				Ok(trusted_payment_id) => {
 					log_debug!(
 						self.logger,
-						"Rebalance trusted transaction initiated, id {}. Waiting for LN payment.",
-						rebalance_id.as_hex()
+						"Rebalance trusted transaction initiated, id {}. Will complete via observer callbacks.",
+						trusted_payment_id.as_hex()
 					);
 
+					// persist trusted payment id
+					state.trusted_payment_id = Some(trusted_payment_id);
+					self.persistence.update_trusted_rebalance_state(state).await;
+
+					// Set active rebalance
+					*rebalance = Some(state);
+
+					// Post initiated event
 					self.event_handler
 						.handle_event(RebalancerEvent::RebalanceInitiated {
 							trigger_id: params.id,
-							trusted_rebalance_payment_id: rebalance_id,
+							trusted_rebalance_payment_id: trusted_payment_id,
 							amount_msat: transfer_amt.milli_sats(),
-						})
-						.await;
-
-					let ln_payment = match self
-						.ln_wallet
-						.await_payment_receipt(expected_hash.to_byte_array())
-						.await
-					{
-						Some(receipt) => receipt,
-						None => {
-							log_error!(self.logger, "Failed to receive rebalance payment!");
-							return;
-						},
-					};
-
-					let trusted_payment = match self
-						.trusted
-						.await_payment_success(expected_hash.to_byte_array())
-						.await
-					{
-						Some(success) => success,
-						None => {
-							log_error!(self.logger, "Failed to send rebalance payment!");
-							return;
-						},
-					};
-
-					log_info!(
-						self.logger,
-						"Rebalance succeeded. Sent trusted tx {} to lightning tx {}",
-						rebalance_id.as_hex(),
-						ln_payment.id.as_hex(),
-					);
-
-					self.event_handler
-						.handle_event(RebalancerEvent::RebalanceSuccessful {
-							trigger_id: params.id,
-							trusted_rebalance_payment_id: rebalance_id,
-							ln_rebalance_payment_id: ln_payment.id,
-							amount_msat: transfer_amt.milli_sats(),
-							fee_msat: ln_payment.fee_paid_msat.unwrap_or_default()
-								+ trusted_payment.fee_paid_msat.unwrap_or_default(),
 						})
 						.await;
 				},
 				Err(e) => {
 					log_info!(self.logger, "Rebalance trusted transaction failed with {e:?}",);
+
+					// Clean up persisted state
+					self.persistence.remove_trusted_rebalance_state().await;
+
+					// Post failure event
+					self.event_handler
+						.handle_event(RebalancerEvent::RebalanceFailed {
+							trigger_id: params.id,
+							trusted_rebalance_payment_id: None,
+							amount_msat: transfer_amt.milli_sats(),
+							reason: format!("Failed to initiate trusted payment: {e:?}"),
+						})
+						.await;
 				},
 			}
 		}
@@ -346,58 +468,446 @@ where
 
 	/// Perform on-chain to lightning rebalance by opening a channel or splicing into an existing one
 	async fn do_onchain_rebalance(&self, params: TriggerParams) {
-		let _ = self.balance_mutex.lock().await;
+		let mut onchain_rebalance = self.active_onchain_rebalance.lock().await;
 
-		let (channel_outpoint, user_channel_id) = if self.ln_wallet.has_channel_with_lsp() {
+		// Check if there's already an active on-chain rebalance
+		if onchain_rebalance.is_some() {
+			log_info!(
+				self.logger,
+				"Skipping on-chain rebalance trigger - already have an active on-chain rebalance"
+			);
+			return;
+		}
+
+		let is_splice = self.ln_wallet.has_channel_with_lsp();
+
+		if is_splice {
 			log_info!(self.logger, "Splicing into channel with LSP with on-chain funds");
-
-			let user_chan_id = match self.ln_wallet.splice_to_lsp_channel(params.amount).await {
-				Ok(chan_id) => chan_id,
-				Err(e) => {
-					log_error!(self.logger, "Failed to open channel with LSP: {e:?}");
-					return;
-				},
-			};
-
-			log_info!(self.logger, "Initiated splice opened with LSP");
-
-			let channel_outpoint = self.ln_wallet.await_splice_pending(user_chan_id).await;
-
-			log_info!(self.logger, "Splice initiated at: {channel_outpoint}");
-
-			(channel_outpoint, user_chan_id)
 		} else {
 			log_info!(self.logger, "Opening channel with LSP with on-chain funds");
+		}
 
-			let user_chan_id = match self.ln_wallet.open_channel_with_lsp(params.amount).await {
+		// Persist state BEFORE initiating the operation to ensure we don't lose track
+		let mut state = OnChainRebalanceState {
+			trigger_id: params.id,
+			user_channel_id: None,
+			amount_sats: params.amount.sats_rounding_up(),
+			is_splice,
+			pending_confirmed: false,
+			channel_outpoint: None,
+		};
+		self.persistence.insert_onchain_rebalance_state(state).await;
+		*onchain_rebalance = Some(state);
+
+		// Now initiate the actual operation
+		let user_channel_id = if is_splice {
+			match self.ln_wallet.splice_to_lsp_channel(params.amount).await {
+				Ok(chan_id) => chan_id,
+				Err(e) => {
+					log_error!(self.logger, "Failed to splice to LSP channel: {e:?}");
+					// Clean up the state if we failed
+					let _ = onchain_rebalance.take();
+					self.persistence.remove_onchain_rebalance_state().await;
+					self.event_handler
+						.handle_event(RebalancerEvent::RebalanceFailed {
+							trigger_id: params.id,
+							trusted_rebalance_payment_id: None,
+							amount_msat: params.amount.milli_sats(),
+							reason: format!("Failed to splice to LSP channel: {e:?}"),
+						})
+						.await;
+					return;
+				},
+			}
+		} else {
+			match self.ln_wallet.open_channel_with_lsp(params.amount).await {
 				Ok(chan_id) => chan_id,
 				Err(e) => {
 					log_error!(self.logger, "Failed to open channel with LSP: {e:?}");
+					// Clean up the state if we failed
+					let _ = onchain_rebalance.take();
+					self.persistence.remove_onchain_rebalance_state().await;
+					self.event_handler
+						.handle_event(RebalancerEvent::RebalanceFailed {
+							trigger_id: params.id,
+							trusted_rebalance_payment_id: None,
+							amount_msat: params.amount.milli_sats(),
+							reason: format!("Failed to open channel with LSP: {e:?}"),
+						})
+						.await;
 					return;
 				},
-			};
-
-			log_info!(self.logger, "Initiated channel opened with LSP");
-
-			let channel_outpoint = self.ln_wallet.await_channel_pending(user_chan_id).await;
-
-			log_info!(self.logger, "Channel open succeeded at: {channel_outpoint}");
-
-			(channel_outpoint, user_chan_id)
+			}
 		};
+
+		// Update state with the user_channel_id
+		state.user_channel_id = Some(user_channel_id);
+		*onchain_rebalance = Some(state);
+		self.persistence.update_onchain_rebalance_state(state).await;
+
+		log_info!(
+			self.logger,
+			"On-chain rebalance initiated for user_channel_id {user_channel_id}. Will complete via observer callback."
+		);
+	}
+
+	/// Called when the trusted wallet confirms sending a payment
+	/// This is part of the observer pattern to handle rebalance completion across restarts
+	pub async fn on_trusted_payment_sent(&self, payment_hash: [u8; 32], fee_msat: Option<u64>) {
+		let mut rebalance = self.active_trusted_rebalance.lock().await;
+
+		if let Some(state) = rebalance.as_mut() {
+			if state.expected_payment_hash == payment_hash {
+				state.trusted_payment_sent = true;
+				state.trusted_fee_msat = fee_msat;
+
+				log_debug!(
+					self.logger,
+					"Trusted payment sent for rebalance {}",
+					payment_hash.as_hex()
+				);
+
+				// Check if rebalance is complete, otherwise persist state
+				if state.ln_payment_received {
+					self.complete_rebalance(*state, &mut rebalance).await;
+				} else {
+					self.persistence.update_trusted_rebalance_state(*state).await;
+				}
+			}
+		}
+	}
+
+	/// Called when the lightning wallet receives a payment
+	/// This is part of the observer pattern to handle rebalance completion across restarts
+	pub async fn on_ln_payment_received(
+		&self, payment_hash: [u8; 32], payment_id: [u8; 32], fee_msat: Option<u64>,
+	) {
+		let mut rebalance = self.active_trusted_rebalance.lock().await;
+
+		if let Some(state) = rebalance.as_mut() {
+			if state.expected_payment_hash == payment_hash {
+				state.ln_payment_received = true;
+				state.ln_payment_id = Some(payment_id);
+				state.ln_fee_msat = fee_msat;
+
+				log_debug!(
+					self.logger,
+					"Lightning payment received for rebalance {}",
+					payment_hash.as_hex()
+				);
+
+				// Check if rebalance is complete, otherwise persist state
+				if state.trusted_payment_sent {
+					self.complete_rebalance(*state, &mut rebalance).await;
+				} else {
+					self.persistence.update_trusted_rebalance_state(*state).await;
+				}
+			}
+		}
+	}
+
+	/// Called when a trusted wallet payment fails
+	/// This is part of the observer pattern to handle rebalance failures
+	pub async fn on_trusted_payment_failed(&self, payment_hash: [u8; 32], reason: String) {
+		let mut rebalance = self.active_trusted_rebalance.lock().await;
+
+		if let Some(state) = rebalance.as_ref() {
+			if state.expected_payment_hash == payment_hash {
+				log_info!(
+					self.logger,
+					"Trusted payment failed for rebalance {}: {}",
+					payment_hash.as_hex(),
+					reason
+				);
+
+				// Post failure event
+				self.event_handler
+					.handle_event(RebalancerEvent::RebalanceFailed {
+						trigger_id: state.trigger_id,
+						trusted_rebalance_payment_id: state.trusted_payment_id,
+						amount_msat: state.amount_msat,
+						reason,
+					})
+					.await;
+
+				// Clean up
+				let _ = rebalance.take();
+				self.persistence.remove_trusted_rebalance_state().await;
+			}
+		}
+	}
+
+	/// Called when a channel or splice becomes pending
+	/// This is part of the observer pattern to handle on-chain rebalance completion across restarts
+	pub async fn on_channel_splice_pending(
+		&self, user_channel_id: u128, channel_outpoint: OutPoint,
+	) {
+		let mut onchain_rebalance = self.active_onchain_rebalance.lock().await;
+
+		// Check if there's an active on-chain rebalance matching this user_channel_id
+		if let Some(state) = onchain_rebalance.as_mut() {
+			if state.user_channel_id == Some(user_channel_id) {
+				state.pending_confirmed = true;
+				state.channel_outpoint = Some(channel_outpoint);
+
+				log_info!(
+					self.logger,
+					"On-chain rebalance pending confirmed for user_channel_id {} at outpoint {}",
+					user_channel_id,
+					channel_outpoint
+				);
+
+				self.complete_onchain_rebalance(*state, &mut onchain_rebalance).await;
+			}
+		}
+	}
+
+	/// Complete an on-chain rebalance by posting the event and cleaning up
+	async fn complete_onchain_rebalance(
+		&self, state: OnChainRebalanceState,
+		onchain_rebalance: &mut tokio::sync::MutexGuard<'_, Option<OnChainRebalanceState>>,
+	) {
+		log_info!(
+			self.logger,
+			"On-chain rebalance completed for user_channel_id {:?} at {}",
+			state.user_channel_id,
+			state.channel_outpoint.expect("channel_outpoint must be set")
+		);
 
 		self.event_handler
 			.handle_event(RebalancerEvent::OnChainRebalanceInitiated {
-				trigger_id: params.id,
-				user_channel_id,
-				channel_outpoint,
+				trigger_id: state.trigger_id,
+				user_channel_id: state.user_channel_id.expect("user_channel_id must be set"),
+				channel_outpoint: state.channel_outpoint.expect("channel_outpoint must be set"),
 			})
 			.await;
+
+		// Clean up
+		let _ = onchain_rebalance.take();
+		self.persistence.remove_onchain_rebalance_state().await;
+	}
+
+	/// Complete a rebalance by posting the success event and cleaning up
+	async fn complete_rebalance(
+		&self, state: RebalanceState,
+		rebalance: &mut tokio::sync::MutexGuard<'_, Option<RebalanceState>>,
+	) {
+		log_info!(
+			self.logger,
+			"Rebalance succeeded. Sent trusted tx {} to lightning tx {}",
+			state.trusted_payment_id.expect("trusted_payment_id must be set").as_hex(),
+			state.ln_payment_id.expect("ln_payment_id must be set").as_hex(),
+		);
+
+		self.event_handler
+			.handle_event(RebalancerEvent::RebalanceSuccessful {
+				trigger_id: state.trigger_id,
+				trusted_rebalance_payment_id: state
+					.trusted_payment_id
+					.expect("trusted_payment_id must be set"),
+				ln_rebalance_payment_id: state.ln_payment_id.expect("ln_payment_id must be set"),
+				amount_msat: state.amount_msat,
+				fee_msat: state.ln_fee_msat.unwrap_or_default()
+					+ state.trusted_fee_msat.unwrap_or_default(),
+			})
+			.await;
+
+		// Clean up
+		let _ = rebalance.take();
+		self.persistence.remove_trusted_rebalance_state().await;
+	}
+
+	/// Recover incomplete rebalances from persistence on startup
+	/// This should be called during wallet initialization
+	///
+	/// Returns true if you should call [`Self::do_trusted_rebalance_if_needed`] again
+	/// to retry any cleaned up rebalances.
+	pub async fn recover_incomplete_trusted_rebalances(&self) -> Result<bool, ()> {
+		let state_opt = self.persistence.get_trusted_rebalance().await?;
+
+		if let Some(mut state) = state_opt {
+			let mut rebalance = self.active_trusted_rebalance.lock().await;
+			log_debug!(
+				self.logger,
+				"Recovering rebalance {} (ln_received: {}, trusted_sent: {}, trusted_payment_id: {:?})",
+				state.expected_payment_hash.as_hex(),
+				state.ln_payment_received,
+				state.trusted_payment_sent,
+				state.trusted_payment_id.map(|id| id.to_lower_hex_string())
+			);
+
+			// If trusted_payment_id is None, we crashed after persisting state but before
+			// persisting the trusted_payment_id. However, the payment might have actually
+			// been sent, we need to check with the trusted wallet.
+			if state.trusted_payment_id.is_none() {
+				log_info!(
+					self.logger,
+					"Rebalance {} has no trusted_payment_id, checking if payment was actually sent",
+					state.expected_payment_hash.as_hex()
+				);
+
+				match self.trusted.find_payment_by_hash(state.expected_payment_hash).await {
+					Ok(Some(pending_info)) => {
+						// Payment was actually sent, Recover the payment id and continue.
+						log_info!(
+							self.logger,
+							"Found pending payment {} for rebalance {}, recovering",
+							pending_info.payment_id.as_hex(),
+							state.expected_payment_hash.as_hex()
+						);
+						state.trusted_payment_id = Some(pending_info.payment_id);
+						// Update persistence with the recovered payment id.
+						self.persistence.update_trusted_rebalance_state(state).await;
+					},
+					Ok(None) => {
+						// The payment was never actually sent. Clean up and retry.
+						log_info!(
+							self.logger,
+							"Rebalance {} was never initiated (no payment found), cleaning up and retrying",
+							state.expected_payment_hash.as_hex()
+						);
+						self.persistence.remove_trusted_rebalance_state().await;
+						return Ok(true);
+					},
+					Err(e) => {
+						log_error!(
+							self.logger,
+							"Failed to query trusted wallet ({e:?}) for rebalance {}, assuming payment was not sent",
+							state.expected_payment_hash.as_hex()
+						);
+						self.persistence.remove_trusted_rebalance_state().await;
+						return Ok(true);
+					},
+				}
+			}
+
+			// If both sides already completed, finalize now
+			if state.ln_payment_received && state.trusted_payment_sent {
+				log_info!(
+					self.logger,
+					"Rebalance {} was already complete, finalizing",
+					state.expected_payment_hash.as_hex()
+				);
+
+				// Temporarily set to complete
+				*rebalance = Some(state);
+				self.complete_rebalance(state, &mut rebalance).await;
+			} else {
+				// Still waiting for one or both sides
+				// Note: We only recover the first incomplete rebalance since we only allow one at a time
+				if rebalance.is_none() {
+					*rebalance = Some(state);
+				} else {
+					debug_assert!(
+						false,
+						"Called recover_incomplete_rebalances with multiple times"
+					);
+				}
+			}
+		}
+
+		Ok(false)
+	}
+
+	/// Recover incomplete on-chain rebalances from persistence on startup
+	/// This should be called during wallet initialization
+	///
+	/// Returns true if you should call [`Self::do_onchain_rebalance_if_needed`] again
+	/// to retry any cleaned up rebalances.
+	pub async fn recover_incomplete_onchain_rebalances(&self) -> Result<bool, ()> {
+		let state_opt = self.persistence.get_onchain_rebalance().await?;
+
+		if let Some(mut state) = state_opt {
+			let mut onchain_rebalance = self.active_onchain_rebalance.lock().await;
+			log_debug!(
+				self.logger,
+				"Recovering on-chain rebalance for user_channel_id {:?} (pending_confirmed: {})",
+				state.user_channel_id,
+				state.pending_confirmed
+			);
+
+			// Check if the channel is already ready by querying LDK (only if user_channel_id is set)
+			if let Some(user_channel_id) = state.user_channel_id {
+				if let Some(outpoint) = self.ln_wallet.get_channel_outpoint(user_channel_id) {
+					// Channel is already pending/ready, complete now
+					log_info!(
+						self.logger,
+						"On-chain rebalance for user_channel_id {user_channel_id} was already pending, finalizing"
+					);
+
+					state.pending_confirmed = true;
+					state.channel_outpoint = Some(outpoint);
+
+					*onchain_rebalance = Some(state);
+					self.complete_onchain_rebalance(state, &mut onchain_rebalance).await;
+				} else {
+					// Still waiting for channel/splice pending
+					if onchain_rebalance.is_none() {
+						*onchain_rebalance = Some(state);
+					} else {
+						debug_assert!(
+							false,
+							"Called recover_incomplete_onchain_rebalances multiple times"
+						);
+					}
+				}
+			} else {
+				// user_channel_id not set yet, we crashed after persisting state but before
+				// persisting the user_channel_id. However, the channel/splice might have actually
+				// been initiated, we need to check with the lightning wallet.
+				log_info!(
+					self.logger,
+					"On-chain rebalance has no user_channel_id, checking if channel was actually opened"
+				);
+
+				match self.ln_wallet.find_pending_lsp_channel() {
+					Some(user_channel_id) => {
+						log_info!(
+							self.logger,
+							"Found pending channel {user_channel_id} for on-chain rebalance, recovering"
+						);
+						state.user_channel_id = Some(user_channel_id);
+						self.persistence.update_onchain_rebalance_state(state).await;
+
+						// Check if it's already pending/ready
+						if let Some(outpoint) = self.ln_wallet.get_channel_outpoint(user_channel_id)
+						{
+							log_info!(
+								self.logger,
+								"Recovered channel {user_channel_id} is already pending, finalizing"
+							);
+							state.pending_confirmed = true;
+							state.channel_outpoint = Some(outpoint);
+							*onchain_rebalance = Some(state);
+							self.complete_onchain_rebalance(state, &mut onchain_rebalance).await;
+						} else {
+							// Still waiting for channel pending
+							*onchain_rebalance = Some(state);
+						}
+					},
+					None => {
+						// Pending channel not found, the splice/channel open was never initiated.
+						// Clean up and retry.
+						log_info!(
+							self.logger,
+							"On-chain rebalance was never initiated (no pending channel found), cleaning up and retrying"
+						);
+						self.persistence.remove_onchain_rebalance_state().await;
+						return Ok(true);
+					},
+				}
+			}
+		}
+
+		Ok(false)
 	}
 
 	/// Stops the rebalancer, waits for any active rebalances to complete
 	pub async fn stop(&self) {
-		log_debug!(self.logger, "Waiting for balance mutex...");
-		let _ = self.balance_mutex.lock().await;
+		log_debug!(self.logger, "Waiting for balance mutexes...");
+		let _ = tokio::join!(
+			self.active_trusted_rebalance.lock(),
+			self.active_onchain_rebalance.lock()
+		);
 	}
 }

--- a/orange-sdk/Cargo.toml
+++ b/orange-sdk/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2024"
 authors = ["benthecarman <benthecarman@live.com>"]
 documentation = "https://docs.rs/orange-sdk/"
 license = "MIT OR Apache-2.0"
-keywords = [ "lightning", "bitcoin", "spark", "cashu" ]
+keywords = ["lightning", "bitcoin", "spark", "cashu"]
 readme = "../README.md"
 
 [lib]
@@ -24,7 +24,7 @@ _cashu-tests = ["_test-utils", "cdk-ldk-node", "cdk/mint", "cdk-sqlite", "cdk-ax
 graduated-rebalancer = { path = "../graduated-rebalancer", version = "0.1.0" }
 
 ldk-node = { version = "0.7.0" }
-lightning-macros = "0.2.0"
+lightning-macros = { workspace = true }
 bitcoin-payment-instructions = { workspace = true, features = ["http"] }
 chrono = { version = "0.4", default-features = false }
 rand = { version = "0.8.5", optional = true }

--- a/orange-sdk/src/event.rs
+++ b/orange-sdk/src/event.rs
@@ -1,4 +1,5 @@
 use crate::logging::Logger;
+use crate::rebalancer::RebalanceEventHandlerHolder;
 use crate::store::{self, PaymentId};
 
 use ldk_node::bitcoin::secp256k1::PublicKey;
@@ -131,6 +132,17 @@ pub enum Event {
 		/// The fee paid, in msats, for the rebalance payment.
 		fee_msat: u64,
 	},
+	/// A rebalance from our trusted wallet has failed.
+	RebalanceFailed {
+		/// The `payment_id` of the transaction that triggered the rebalance.
+		trigger_payment_id: PaymentId,
+		/// The `payment_id` of the rebalance payment sent from the trusted wallet.
+		trusted_rebalance_payment_id: Option<[u8; 32]>,
+		/// The amount, in msats, of the rebalance payment.
+		amount_msat: u64,
+		/// The reason for the failure.
+		reason: String,
+	},
 	/// We have initiated a splice and are waiting for it to confirm.
 	SplicePending {
 		/// The `channel_id` of the channel.
@@ -198,6 +210,12 @@ impl_writeable_tlv_based_enum!(Event,
 		(3, counterparty_node_id, required),
 		(5, user_channel_id, required),
 		(7, new_funding_txo, required),
+	},
+	(9, RebalanceFailed) => {
+		(0, trigger_payment_id, required),
+		(2, trusted_rebalance_payment_id, option),
+		(4, amount_msat, required),
+		(6, reason, required),
 	},
 );
 
@@ -321,9 +339,8 @@ pub(crate) struct LdkEventHandler {
 	pub(crate) event_queue: Arc<EventQueue>,
 	pub(crate) ldk_node: Arc<ldk_node::Node>,
 	pub(crate) tx_metadata: store::TxMetadataStore,
-	pub(crate) payment_receipt_sender: watch::Sender<()>,
-	pub(crate) channel_pending_sender: watch::Sender<u128>,
 	pub(crate) splice_pending_sender: watch::Sender<u128>,
+	pub(crate) rebalance_event_handler: RebalanceEventHandlerHolder,
 	pub(crate) logger: Arc<Logger>,
 }
 
@@ -399,7 +416,11 @@ impl LdkEventHandler {
 				{
 					log_error!(self.logger, "Failed to add PaymentReceived event: {e:?}");
 				}
-				let _ = self.payment_receipt_sender.send(());
+
+				// Notify rebalancer if this might be a rebalance payment
+				self.rebalance_event_handler
+					.notify_ln_payment_received(payment_hash.0, payment_id.0, lsp_fee_msats)
+					.await;
 			},
 			ldk_node::Event::PaymentForwarded { .. } => {},
 			ldk_node::Event::PaymentClaimable { .. } => {
@@ -419,6 +440,11 @@ impl LdkEventHandler {
 			} => {
 				let funding_txo = funding_txo.unwrap(); // safe
 
+				// Notify rebalancer if this might be an on-chain rebalance
+				self.rebalance_event_handler
+					.notify_channel_splice_pending(user_channel_id.0, funding_txo)
+					.await;
+
 				if let Err(e) = self
 					.event_queue
 					.add_event(Event::ChannelOpened {
@@ -432,7 +458,6 @@ impl LdkEventHandler {
 					log_error!(self.logger, "Failed to add ChannelOpened event: {e:?}");
 					return;
 				}
-				let _ = self.channel_pending_sender.send(user_channel_id.0);
 			},
 			ldk_node::Event::ChannelClosed {
 				channel_id,
@@ -465,6 +490,12 @@ impl LdkEventHandler {
 				new_funding_txo,
 			} => {
 				log_debug!(self.logger, "Received SplicePending event {event:?}");
+
+				// Notify rebalancer if this might be an on-chain rebalance
+				self.rebalance_event_handler
+					.notify_channel_splice_pending(user_channel_id.0, new_funding_txo)
+					.await;
+
 				let _ = self.splice_pending_sender.send(user_channel_id.0);
 
 				if let Err(e) = self

--- a/orange-sdk/src/ffi/orange/mod.rs
+++ b/orange-sdk/src/ffi/orange/mod.rs
@@ -274,6 +274,17 @@ pub enum Event {
 		/// The outpoint of the channel's splice funding transaction.
 		new_funding_txo: String,
 	},
+	/// A rebalance from our trusted wallet has failed.
+	RebalanceFailed {
+		/// The `payment_id` of the transaction that triggered the rebalance.
+		trigger_payment_id: PaymentId,
+		/// The `payment_id` of the rebalance payment sent from the trusted wallet.
+		trusted_rebalance_payment_id: Option<Vec<u8>>,
+		/// The amount, in msats, of the rebalance payment.
+		amount_msat: u64,
+		/// The reason for the failure.
+		reason: String,
+	},
 }
 
 impl From<OrangeEvent> for Event {
@@ -360,6 +371,17 @@ impl From<OrangeEvent> for Event {
 				ln_rebalance_payment_id: ln_rebalance_payment_id.to_vec(),
 				amount_msat,
 				fee_msat,
+			},
+			OrangeEvent::RebalanceFailed {
+				trigger_payment_id,
+				trusted_rebalance_payment_id,
+				amount_msat,
+				reason,
+			} => Event::RebalanceFailed {
+				trigger_payment_id: trigger_payment_id.into(),
+				trusted_rebalance_payment_id: trusted_rebalance_payment_id.map(|id| id.to_vec()),
+				amount_msat,
+				reason,
 			},
 			OrangeEvent::SplicePending {
 				channel_id,

--- a/orange-sdk/src/trusted_wallet/spark/mod.rs
+++ b/orange-sdk/src/trusted_wallet/spark/mod.rs
@@ -3,8 +3,11 @@
 pub(crate) mod spark_store;
 
 use crate::bitcoin::Network;
+use crate::bitcoin::hex::DisplayHex;
 use crate::bitcoin::hex::FromHex;
 use crate::logging::Logger;
+use crate::rebalancer::RebalanceEventHandlerHolder;
+use crate::runtime::Runtime;
 use crate::store::{PaymentId, TxMetadataStore, TxStatus};
 use crate::trusted_wallet::{Payment, TrustedError, TrustedWalletInterface};
 use crate::{Event, EventQueue, InitFailure, Seed, WalletConfig};
@@ -20,16 +23,13 @@ use bitcoin_payment_instructions::amount::Amount;
 
 use breez_sdk_spark::{
 	BreezSdk, EventListener, GetInfoRequest, ListPaymentsRequest, OptimizationConfig,
-	PaymentDetails, PaymentStatus, PaymentType, PrepareSendPaymentRequest, ReceivePaymentMethod,
+	PaymentDetails, PaymentType, PrepareSendPaymentRequest, ReceivePaymentMethod,
 	ReceivePaymentRequest, RegisterLightningAddressRequest, SdkBuilder, SdkError, SdkEvent,
 	SendPaymentMethod, SendPaymentRequest,
 };
 
-use graduated_rebalancer::ReceivedLightningPayment;
-
 use tokio::sync::watch;
 
-use crate::runtime::Runtime;
 use std::future::Future;
 use std::pin::Pin;
 use std::str::FromStr;
@@ -97,7 +97,6 @@ impl SparkWalletConfig {
 pub(crate) struct Spark {
 	spark_wallet: Arc<BreezSdk>,
 	shutdown_sender: watch::Sender<()>,
-	payment_success_flag: watch::Receiver<()>,
 	logger: Arc<Logger>,
 }
 
@@ -249,36 +248,6 @@ impl TrustedWalletInterface for Spark {
 		})
 	}
 
-	fn await_payment_success(
-		&self, payment_hash: [u8; 32],
-	) -> Pin<Box<dyn Future<Output = Option<ReceivedLightningPayment>> + Send + '_>> {
-		Box::pin(async move {
-			loop {
-				let res =
-					self.spark_wallet.list_payments(ListPaymentsRequest::default()).await.ok()?;
-
-				let tx = res.payments.into_iter().find(|p| {
-					if let Some(PaymentDetails::Lightning { htlc_details, .. }) = &p.details {
-						let hash: Option<[u8; 32]> =
-							FromHex::from_hex(&htlc_details.payment_hash).ok();
-						hash == Some(payment_hash)
-					} else {
-						false
-					}
-				})?;
-
-				if tx.status == PaymentStatus::Completed {
-					return Some(ReceivedLightningPayment {
-						id: payment_hash,
-						fee_paid_msat: Some((tx.fees * 1_000) as u64),
-					});
-				}
-
-				self.await_payment_success().await;
-			}
-		})
-	}
-
 	fn get_lightning_address(
 		&self,
 	) -> Pin<Box<dyn Future<Output = Result<Option<String>, TrustedError>> + Send + '_>> {
@@ -313,13 +282,41 @@ impl TrustedWalletInterface for Spark {
 			let _ = self.shutdown_sender.send(());
 		})
 	}
+
+	fn find_payment_by_hash(
+		&self, payment_hash: [u8; 32],
+	) -> Pin<Box<dyn Future<Output = Result<Option<[u8; 32]>, TrustedError>> + Send + '_>> {
+		Box::pin(async move {
+			let payment_hash_hex = payment_hash.to_lower_hex_string();
+			let resp = self.spark_wallet.list_payments(ListPaymentsRequest::default()).await?;
+
+			for payment in resp.payments {
+				// Only look at outbound payments
+				if payment.payment_type != PaymentType::Send {
+					continue;
+				}
+
+				// Check if the payment hash matches
+				if let Some(PaymentDetails::Lightning { htlc_details, .. }) = &payment.details {
+					if htlc_details.payment_hash == payment_hash_hex {
+						let id = parse_payment_id(&payment.id)?;
+						return Ok(Some(id));
+					}
+				}
+			}
+
+			Ok(None)
+		})
+	}
 }
 
 impl Spark {
 	/// Initialize a new Spark wallet instance with the given configuration.
+	#[allow(clippy::too_many_arguments)]
 	pub(crate) async fn init(
 		config: &WalletConfig, spark_config: SparkWalletConfig, store: Arc<DynStore>,
-		event_queue: Arc<EventQueue>, tx_metadata: TxMetadataStore, logger: Arc<Logger>,
+		event_queue: Arc<EventQueue>, tx_metadata: TxMetadataStore,
+		rebalance_event_handler: RebalanceEventHandlerHolder, logger: Arc<Logger>,
 		runtime: Arc<Runtime>,
 	) -> Result<Self, InitFailure> {
 		let spark_config: breez_sdk_spark::Config =
@@ -344,12 +341,11 @@ impl Spark {
 		log_info!(logger, "Started Spark wallet!");
 
 		let (shutdown_sender, shutdown_receiver) = watch::channel::<()>(());
-		let (payment_success_sender, payment_success_flag) = watch::channel(());
 
 		let listener = SparkEventHandler {
 			event_queue: Arc::clone(&event_queue),
 			tx_metadata,
-			payment_success_sender,
+			rebalance_event_handler,
 			logger: Arc::clone(&logger),
 		};
 
@@ -364,20 +360,14 @@ impl Spark {
 
 		log_info!(logger, "Spark wallet initialized");
 
-		Ok(Spark { spark_wallet, shutdown_sender, payment_success_flag, logger })
-	}
-
-	pub(crate) async fn await_payment_success(&self) {
-		let mut flag = self.payment_success_flag.clone();
-		flag.mark_unchanged();
-		let _ = flag.changed().await;
+		Ok(Spark { spark_wallet, shutdown_sender, logger })
 	}
 }
 
 struct SparkEventHandler {
 	event_queue: Arc<EventQueue>,
 	tx_metadata: TxMetadataStore,
-	payment_success_sender: watch::Sender<()>,
+	rebalance_event_handler: RebalanceEventHandlerHolder,
 	logger: Arc<Logger>,
 }
 
@@ -438,16 +428,6 @@ impl SparkEventHandler {
 							map.get(&payment_id).is_some_and(|m| m.ty.is_rebalance())
 						};
 
-						if is_rebalance {
-							log_info!(
-								self.logger,
-								"Ignoring successful payment event for rebalance payment: {payment_id:?}"
-							);
-							// make sure we still send payment success
-							self.payment_success_sender.send(()).unwrap();
-							return Ok(());
-						}
-
 						let preimage_hex = htlc_details.preimage.ok_or_else(|| {
 							TrustedError::Other(
 								"Payment succeeded but preimage is missing".to_string(),
@@ -461,6 +441,19 @@ impl SparkEventHandler {
 							.map_err(|e| {
 								TrustedError::Other(format!("Invalid payment_hash hex: {e:?}"))
 							})?;
+
+						if is_rebalance {
+							log_info!(
+								self.logger,
+								"Notifying rebalancer of successful trusted payment: {payment_id:?}"
+							);
+							// Notify the rebalance event handler
+							let fee_msat = Some((payment.fees * 1_000) as u64);
+							self.rebalance_event_handler
+								.notify_trusted_payment_sent(payment_hash, fee_msat)
+								.await;
+							return Ok(());
+						}
 
 						if self.tx_metadata.set_preimage(payment_id, preimage).await.is_err() {
 							log_error!(
@@ -477,8 +470,6 @@ impl SparkEventHandler {
 								fee_paid_msat: Some((payment.fees * 1_000) as u64), // convert to msats
 							})
 							.await?;
-
-						self.payment_success_sender.send(()).unwrap();
 					},
 					_ => {
 						log_debug!(self.logger, "Unsupported payment details for Send: {payment:?}")
@@ -533,6 +524,11 @@ impl SparkEventHandler {
 			PaymentType::Send => match payment.details {
 				Some(PaymentDetails::Lightning { htlc_details, .. }) => {
 					let payment_id = PaymentId::Trusted(id);
+					let payment_hash: [u8; 32] = FromHex::from_hex(&htlc_details.payment_hash)
+						.map_err(|e| {
+							TrustedError::Other(format!("Invalid payment_hash hex: {e:?}"))
+						})?;
+
 					let is_rebalance = {
 						let map = self.tx_metadata.read();
 						map.get(&payment_id).is_some_and(|m| m.ty.is_rebalance())
@@ -541,15 +537,15 @@ impl SparkEventHandler {
 					if is_rebalance {
 						log_info!(
 							self.logger,
-							"Ignoring failed payment event for rebalance payment: {payment_id:?}"
+							"Notifying rebalancer of failed trusted payment: {payment_id:?}"
 						);
+						// Notify the rebalance event handler
+						let reason = format!("Spark payment failed for payment {}", payment.id);
+						self.rebalance_event_handler
+							.notify_trusted_payment_failed(payment_hash, reason)
+							.await;
 						return Ok(());
 					}
-
-					let payment_hash: [u8; 32] = FromHex::from_hex(&htlc_details.payment_hash)
-						.map_err(|e| {
-							TrustedError::Other(format!("Invalid payment_hash hex: {e:?}"))
-						})?;
 
 					self.event_queue
 						.add_event(Event::PaymentFailed {


### PR DESCRIPTION
Previously, we would await payment successes before doing a rebalance successful event. This would cause issues if the app was closed during a rebalance. This adds handling so the GraduatedRebalancer is now event based and persists its state. We also now have better handling for failed rebalances to go along with it.

