### PR TITLE
Add more Apple-related paths to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,8 +5,12 @@ Cargo.lock
 maven-central-package
 *.so
 
+# macOS system files
+.DS_Store
+
 # Ignore generated swift related files
 .swiftpm/
+.build/
 OrangeSDKFFI.*
 orange_sdk.swift
 liborange_sdk.dylib


### PR DESCRIPTION
This short PR adds some Apple/Swift/macOS paths to be ignored by version control, for better developer ergonomics.