### PR TITLE
Apply regtest fast-sync override to Electrum chain source

### DIFF
--- a/orange-sdk/src/lightning_wallet.rs
+++ b/orange-sdk/src/lightning_wallet.rs
@@ -147,7 +147,20 @@ impl LightningWallet {
 					},
 				}
 			},
-			ChainSource::Electrum(url) => builder.set_chain_source_electrum(url, None),
+			ChainSource::Electrum(url) => {
+				let sync_config = if config.network == Network::Regtest {
+					Some(ldk_node::config::ElectrumSyncConfig {
+						background_sync_config: Some(BackgroundSyncConfig {
+							onchain_wallet_sync_interval_secs: 2,
+							lightning_wallet_sync_interval_secs: 2,
+							fee_rate_cache_update_interval_secs: 30,
+						}),
+					})
+				} else {
+					None
+				};
+				builder.set_chain_source_electrum(url, sync_config)
+			},
 			ChainSource::BitcoindRPC { host, port, user, password } => {
 				builder.set_chain_source_bitcoind_rpc(host, port, user, password)
 			},


### PR DESCRIPTION
Closes #54.

`set_chain_source_electrum(url, None)` falls through to ldk-node's
default 80s/30s `BackgroundSyncConfig`. The Esplora arm a few lines
above already overrides this to 2s/2s/30s on `Network::Regtest`;
this mirrors the same override on the Electrum arm.

Mainnet behavior is unchanged — non-regtest networks still pass `None`
and use ldk-node's defaults.

## Testing

**What was verified:**
- `cargo fmt --check` — clean
- `./ci/check-lint.sh` (clippy `-D warnings` + `cargo doc`) — clean
- End-to-end timing against a downstream consumer using `ChainSource::Electrum`
  on regtest: time from on-chain broadcast (`bitcoin-cli sendtoaddress` + 6
  blocks mined) to wallet-side detection of `pending_balance > 0` dropped
  from **~80s → ~10s**, matching the expected behavior change.

**What was not run:** the existing `tests/integration_tests.rs` suite
exercises only `ChainSource::Esplora` and `ChainSource::BitcoinRpc` — there
is no Electrum-flavored test fixture in the repo today, so the suite cannot
gate this change either way. Happy to add one in a follow-up if helpful.