### PR TITLE
Fix receive URI source

### DIFF
--- a/orange-sdk/src/lib.rs
+++ b/orange-sdk/src/lib.rs
@@ -1101,7 +1101,7 @@ impl Wallet {
 			(
 				self.inner.tunables.enable_amountless_receive_on_chain,
 				self.inner.trusted.get_bolt11_invoice(amount).await?,
-				false,
+				true,
 			)
 		};
 		if enable_onchain {

--- a/orange-sdk/tests/integration_tests.rs
+++ b/orange-sdk/tests/integration_tests.rs
@@ -43,6 +43,7 @@ async fn test_receive_to_trusted() {
 		assert!(recv_amt < limit.trusted_balance_limit);
 
 		let uri = wallet.get_single_use_receive_uri(Some(recv_amt)).await.unwrap();
+		assert!(uri.from_trusted);
 		let payment_id = third_party.bolt11_payment().send(&uri.invoice, None).unwrap();
 
 		// wait for payment success from payer side
@@ -189,6 +190,7 @@ async fn test_sweep_to_ln() {
 			Amount::from_milli_sats(limit.trusted_balance_limit.milli_sats() / 2).unwrap();
 
 		let uri = wallet.get_single_use_receive_uri(Some(recv_amt)).await.unwrap();
+		assert!(uri.from_trusted);
 		third_party.bolt11_payment().send(&uri.invoice, None).unwrap();
 
 		// wait for balance update on wallet side
@@ -1451,6 +1453,7 @@ async fn test_threshold_boundary_onchain_receive_threshold() {
 				uri.invoice.amount_milli_satoshis().is_none(),
 				"Amountless invoice should have no fixed amount"
 			);
+			assert!(uri.from_trusted, "Amountless receive should use a trusted-wallet invoice");
 		}
 	})
 	.await;

--- a/orange-sdk/tests/test_utils.rs
+++ b/orange-sdk/tests/test_utils.rs
@@ -650,6 +650,7 @@ pub async fn open_channel_from_lsp(wallet: &orange_sdk::Wallet, payer: Arc<Node>
 	let recv_amt = limit.trusted_balance_limit.saturating_add(limit.trusted_balance_limit);
 
 	let uri = wallet.get_single_use_receive_uri(Some(recv_amt)).await.unwrap();
+	assert!(!uri.from_trusted);
 	let payment_id = payer.bolt11_payment().send(&uri.invoice, None).unwrap();
 
 	// wait for payment success from payer side


### PR DESCRIPTION
Mark amountless receive URIs as trusted-wallet invoices and extend integration coverage for trusted and self-custodial receive URI source decisions.