### PR TITLE
Add private-key-knowledge VSS authentication

### DIFF
--- a/bindings/swift/Sources/OrangeSDK/OrangeSDK.swift
+++ b/bindings/swift/Sources/OrangeSDK/OrangeSDK.swift
@@ -5296,6 +5296,7 @@ public enum VssAuth {
      */
     case fixedHeaders([String: String]
     )
+    case sigsAuth
 }
 
 
@@ -5319,6 +5320,8 @@ public struct FfiConverterTypeVssAuth: FfiConverterRustBuffer {
         case 2: return .fixedHeaders(try FfiConverterDictionaryStringString.read(from: &buf)
         )
         
+        case 3: return .sigsAuth
+
         default: throw UniffiInternalError.unexpectedEnumCase
         }
     }
@@ -5336,6 +5339,10 @@ public struct FfiConverterTypeVssAuth: FfiConverterRustBuffer {
             writeInt(&buf, Int32(2))
             FfiConverterDictionaryStringString.write(v1, into: &buf)
             
+
+        case .sigsAuth:
+            writeInt(&buf, Int32(3))
+
         }
     }
 }

--- a/examples/cli/src/main.rs
+++ b/examples/cli/src/main.rs
@@ -38,8 +38,9 @@ struct Cli {
 	/// local SQLite for all wallet persistence.
 	#[arg(long)]
 	vss_url: Option<String>,
-	/// LNURL-auth server URL for VSS authentication. When omitted, fixed
-	/// headers (possibly empty) are used instead.
+	/// LNURL-auth server URL for VSS authentication. When omitted, VSS uses
+	/// sigs auth unless fixed headers are provided. Sigs auth requires no
+	/// setup on VSS server; it works out of the box.
 	#[arg(long, requires = "vss_url")]
 	vss_lnurl_auth_url: Option<String>,
 	/// Fixed HTTP header to attach to every VSS request, in `Key:Value` form.
@@ -62,6 +63,7 @@ fn build_storage_config(cli: &Cli, storage_path: &str) -> StorageConfig {
 	let store_id = "orange-cli".to_string();
 	let headers = match cli.vss_lnurl_auth_url.clone() {
 		Some(url) => VssAuth::LNURLAuthServer(url),
+		None if cli.vss_headers.is_empty() => VssAuth::SigsAuth,
 		None => VssAuth::FixedHeaders(cli.vss_headers.iter().cloned().collect::<HashMap<_, _>>()),
 	};
 	println!(

--- a/orange-sdk/src/ffi/orange/config.rs
+++ b/orange-sdk/src/ffi/orange/config.rs
@@ -75,6 +75,13 @@ pub enum VssAuth {
 	/// A fixed set of HTTP headers included as-is on every request made to
 	/// VSS.
 	FixedHeaders(HashMap<String, String>),
+	/// Simple authentication scheme where access is granted by the knowledge of a private key.
+	///
+	/// There is no specific restriction of who is allowed to store data in VSS using this
+	/// authentication scheme, only that each user is only allowed to store and access data for
+	/// which they have a corresponding private key. Thus, you must ensure new user accounts are
+	/// appropriately rate-limited or access to the VSS server is somehow limited.
+	SigsAuth,
 }
 
 impl From<VssAuth> for OrangeVssAuth {
@@ -82,6 +89,7 @@ impl From<VssAuth> for OrangeVssAuth {
 		match auth {
 			VssAuth::LNURLAuthServer(url) => OrangeVssAuth::LNURLAuthServer(url),
 			VssAuth::FixedHeaders(headers) => OrangeVssAuth::FixedHeaders(headers),
+			VssAuth::SigsAuth => OrangeVssAuth::SigsAuth,
 		}
 	}
 }
@@ -91,6 +99,7 @@ impl From<OrangeVssAuth> for VssAuth {
 		match auth {
 			OrangeVssAuth::LNURLAuthServer(url) => VssAuth::LNURLAuthServer(url),
 			OrangeVssAuth::FixedHeaders(headers) => VssAuth::FixedHeaders(headers),
+			OrangeVssAuth::SigsAuth => VssAuth::SigsAuth,
 		}
 	}
 }

--- a/orange-sdk/src/lib.rs
+++ b/orange-sdk/src/lib.rs
@@ -189,6 +189,13 @@ pub enum VssAuth {
 	/// A fixed set of HTTP headers included as-is on every request made to
 	/// VSS.
 	FixedHeaders(HashMap<String, String>),
+	/// Simple authentication scheme where access is granted by the knowledge of a private key.
+	///
+	/// There is no specific restriction of who is allowed to store data in VSS using this
+	/// authentication scheme, only that each user is only allowed to store and access data for
+	/// which they have a corresponding private key. Thus, you must ensure new user accounts are
+	/// appropriately rate-limited or access to the VSS server is somehow limited.
+	SigsAuth,
 }
 
 /// Configuration for a [Versioned Storage Service (VSS)] backend.
@@ -581,10 +588,11 @@ impl Wallet {
 					config.network,
 				);
 				let vss_store = match &vss_config.headers {
-					VssAuth::FixedHeaders(h) => builder.build_with_fixed_headers(h.clone())?,
 					VssAuth::LNURLAuthServer(url) => {
 						builder.build_with_lnurl(url.clone(), HashMap::new())?
 					},
+					VssAuth::FixedHeaders(h) => builder.build_with_fixed_headers(h.clone())?,
+					VssAuth::SigsAuth => builder.build_with_sigs_auth(HashMap::new())?,
 				};
 				Arc::new(vss_store)
 			},


### PR DESCRIPTION
```
    Add private-key-knowledge VSS authentication

    In PR https://github.com/lightningdevkit/ldk-node/pull/755, we shipped
    a VSS authentication scheme in ldk-node that grants access to data
    stored in VSS based on the knowledge of a private key. This
    authentication scheme is the default method of authentication to VSS
    server in ldk-node.

    Here we wire up this authentication scheme to the public API of this
    crate.

    With this commit, if only the `--vss-url` argument is passed to the cli
    example, with no other VSS arguments, sigs auth is now used. VSS server
    default builds expect this authentication mechanism, and it works out of
    the box, so it is very demo-friendly.

    First launch VSS server:

    `cargo run -- server/vss-server-config.toml`

    then launch the cli example against VSS:

    `cargo run -- --vss-url http://127.0.0.1:8080/vss`

    Commit written with codex.
```