### PR TITLE
Add MPP fallback across trusted and lightning balances

### DIFF
--- a/orange-sdk/src/event.rs
+++ b/orange-sdk/src/event.rs
@@ -1,5 +1,5 @@
 use crate::logging::Logger;
-use crate::store::{self, PaymentId};
+use crate::store::{self, MppOutcome, PaymentId, TxMetadataStore, TxType};
 
 use crate::dyn_store::DynStore;
 use ldk_node::bitcoin::hashes::Hash;
@@ -15,7 +15,7 @@ use ldk_node::lightning_types::payment::{PaymentHash, PaymentPreimage};
 use ldk_node::payment::{ConfirmationStatus, PaymentKind};
 use ldk_node::{CustomTlvRecord, UserChannelId};
 
-use std::collections::VecDeque;
+use std::collections::{HashMap, VecDeque};
 use std::sync::Arc;
 use std::task::{Poll, Waker};
 use std::time::SystemTime;
@@ -209,21 +209,114 @@ impl_writeable_tlv_based_enum!(Event,
 /// [`Wallet`]: [`crate::Wallet`]
 pub struct EventQueue {
 	queue: Arc<Mutex<VecDeque<Event>>>,
+	pending_mpp_events: Arc<Mutex<HashMap<PaymentHash, Vec<Event>>>>,
 	waker: Arc<Mutex<Option<Waker>>>,
 	kv_store: Arc<dyn DynStore>,
+	tx_metadata: TxMetadataStore,
 	logger: Arc<Logger>,
 }
 
 impl EventQueue {
-	pub(crate) fn new(kv_store: Arc<dyn DynStore>, logger: Arc<Logger>) -> Self {
+	pub(crate) fn new(
+		kv_store: Arc<dyn DynStore>, tx_metadata: TxMetadataStore, logger: Arc<Logger>,
+	) -> Self {
 		let queue = Arc::new(Mutex::new(VecDeque::new()));
+		let pending_mpp_events = Arc::new(Mutex::new(HashMap::new()));
 		let waker = Arc::new(Mutex::new(None));
-		Self { queue, waker, kv_store, logger }
+		Self { queue, pending_mpp_events, waker, kv_store, tx_metadata, logger }
+	}
+
+	/// Starts buffering terminal events for a multi-path payment while its leg metadata is being
+	/// registered.
+	pub(crate) async fn begin_mpp_setup(&self, payment_hash: PaymentHash) {
+		self.pending_mpp_events.lock().await.entry(payment_hash).or_default();
+	}
+
+	/// Stops buffering terminal events for a multi-path payment and re-processes any events that
+	/// arrived before the leg metadata was registered.
+	pub(crate) async fn finish_mpp_setup(
+		&self, payment_hash: PaymentHash,
+	) -> Result<(), ldk_node::lightning::io::Error> {
+		let pending_events = self.pending_mpp_events.lock().await.remove(&payment_hash);
+		if let Some(events) = pending_events {
+			for event in events {
+				self.add_event(event).await?;
+			}
+		}
+		Ok(())
 	}
 
 	pub(crate) async fn add_event(
 		&self, event: Event,
 	) -> Result<(), ldk_node::lightning::io::Error> {
+		// Outgoing payments split across the trusted and lightning wallets emit a terminal event per
+		// leg. Record each leg's result onto the shared, persisted metadata; the leg that completes
+		// the payment yields the single combined event we surface instead of the per-leg ones.
+		match &event {
+			Event::PaymentSuccessful { payment_id, payment_preimage, fee_paid_msat, .. }
+				if self.is_mpp_leg(payment_id) =>
+			{
+				let combined = self
+					.tx_metadata
+					.record_mpp_leg(
+						*payment_id,
+						Some((fee_paid_msat.unwrap_or(0), payment_preimage.0)),
+					)
+					.await;
+				return self.push_combined_mpp(combined).await;
+			},
+			Event::PaymentFailed { payment_id, .. } if self.is_mpp_leg(payment_id) => {
+				let combined = self.tx_metadata.record_mpp_leg(*payment_id, None).await;
+				return self.push_combined_mpp(combined).await;
+			},
+			_ => {},
+		}
+
+		if let Some(payment_hash) = terminal_payment_hash(&event) {
+			let mut pending_mpp_events = self.pending_mpp_events.lock().await;
+			if let Some(events) = pending_mpp_events.get_mut(&payment_hash) {
+				events.push(event);
+				return Ok(());
+			}
+		}
+
+		self.push_event(event).await
+	}
+
+	/// Whether `id` identifies a leg of a multi-path payment.
+	fn is_mpp_leg(&self, id: &PaymentId) -> bool {
+		matches!(self.tx_metadata.read().get(id).map(|m| m.ty), Some(TxType::MppPayment { .. }))
+	}
+
+	/// Surfaces the single combined event for a multi-path payment, or nothing if the payment is
+	/// still waiting on its other leg (or already produced its combined event).
+	async fn push_combined_mpp(
+		&self, combined: Option<(PaymentId, MppOutcome)>,
+	) -> Result<(), ldk_node::lightning::io::Error> {
+		match combined {
+			Some((surface_id, MppOutcome::Succeeded { payment_hash, preimage, fee_msat })) => {
+				self.push_event(Event::PaymentSuccessful {
+					payment_id: surface_id,
+					payment_hash: PaymentHash(payment_hash),
+					payment_preimage: PaymentPreimage(preimage),
+					fee_paid_msat: Some(fee_msat),
+				})
+				.await
+			},
+			Some((surface_id, MppOutcome::Failed { payment_hash })) => {
+				self.push_event(Event::PaymentFailed {
+					payment_id: surface_id,
+					payment_hash: Some(PaymentHash(payment_hash)),
+					reason: None,
+				})
+				.await
+			},
+			None => Ok(()),
+		}
+	}
+
+	/// Appends an event to the queue and persists it, waking any pending consumer.
+	async fn push_event(&self, event: Event) -> Result<(), ldk_node::lightning::io::Error> {
 		{
 			let mut locked_queue = self.queue.lock().await;
 			locked_queue.push_back(event);
@@ -282,6 +375,104 @@ impl EventQueue {
 			e
 		})?;
 		Ok(())
+	}
+}
+
+fn terminal_payment_hash(event: &Event) -> Option<PaymentHash> {
+	match event {
+		Event::PaymentSuccessful { payment_hash, .. } => Some(*payment_hash),
+		Event::PaymentFailed { payment_hash, .. } => *payment_hash,
+		_ => None,
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::logging::LoggerType;
+	use crate::store::{PaymentId, PaymentType, TxMetadata, TxMetadataStore, TxType};
+	use ldk_node::io::sqlite_store::SqliteStore;
+	use std::path::PathBuf;
+	use std::time::{Duration, UNIX_EPOCH};
+
+	fn temp_sqlite_store() -> (PathBuf, Arc<dyn DynStore>) {
+		let path = std::env::temp_dir().join(format!(
+			"orange-sdk-event-mpp-buffer-test-{}",
+			SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_nanos()
+		));
+		let store = SqliteStore::new(path.clone(), Some("orange.sqlite".to_string()), None)
+			.expect("sqlite store");
+		(path, Arc::new(store))
+	}
+
+	fn mpp_metadata(surface_id: PaymentId, lightning_leg: [u8; 32]) -> TxMetadata {
+		TxMetadata {
+			ty: TxType::MppPayment {
+				surface_id,
+				lightning_leg,
+				total_amount_msat: 200_000,
+				ty: PaymentType::OutgoingLightningBolt11 { payment_preimage: None },
+				trusted_fee_msat: None,
+				lightning_fee_msat: None,
+				preimage: None,
+				failed: false,
+				finalized: false,
+			},
+			time: Duration::from_secs(1),
+		}
+	}
+
+	#[tokio::test]
+	async fn pending_mpp_setup_buffers_terminal_events_until_metadata_exists() {
+		let (_path, store) = temp_sqlite_store();
+		let tx_metadata = TxMetadataStore::new(Arc::clone(&store)).await;
+		let queue = EventQueue::new(
+			store,
+			tx_metadata.clone(),
+			Arc::new(Logger::new(&LoggerType::LogFacade).expect("logger")),
+		);
+
+		let payment_hash = PaymentHash([3u8; 32]);
+		let surface_id = PaymentId::Trusted([7u8; 32]);
+		let lightning_id = PaymentId::SelfCustodial(payment_hash.0);
+		let preimage = PaymentPreimage([1u8; 32]);
+
+		queue.begin_mpp_setup(payment_hash).await;
+		queue
+			.add_event(Event::PaymentSuccessful {
+				payment_id: surface_id,
+				payment_hash,
+				payment_preimage: preimage,
+				fee_paid_msat: Some(1_000),
+			})
+			.await
+			.expect("buffer event");
+		assert_eq!(queue.next_event().await, None);
+
+		tx_metadata.insert(surface_id, mpp_metadata(surface_id, payment_hash.0)).await;
+		tx_metadata.upsert(lightning_id, mpp_metadata(surface_id, payment_hash.0)).await;
+		queue.finish_mpp_setup(payment_hash).await.expect("replay buffered events");
+		assert_eq!(queue.next_event().await, None);
+
+		queue
+			.add_event(Event::PaymentSuccessful {
+				payment_id: lightning_id,
+				payment_hash,
+				payment_preimage: preimage,
+				fee_paid_msat: Some(2_000),
+			})
+			.await
+			.expect("complete mpp");
+
+		assert_eq!(
+			queue.next_event().await,
+			Some(Event::PaymentSuccessful {
+				payment_id: surface_id,
+				payment_hash,
+				payment_preimage: preimage,
+				fee_paid_msat: Some(3_000),
+			})
+		);
 	}
 }
 

--- a/orange-sdk/src/lib.rs
+++ b/orange-sdk/src/lib.rs
@@ -8,7 +8,7 @@ pub use bitcoin_payment_instructions::PaymentMethod;
 use bitcoin_payment_instructions::amount::Amount;
 
 use crate::rebalancer::{OrangeRebalanceEventHandler, OrangeTrigger};
-use crate::store::{TxMetadata, TxMetadataStore, TxType};
+use crate::store::{MppLegKind, MppMerge, TxMetadata, TxMetadataStore, TxType};
 #[cfg(feature = "cashu")]
 use crate::trusted_wallet::cashu::Cashu;
 #[cfg(feature = "_test-utils")]
@@ -611,9 +611,10 @@ impl Wallet {
 			},
 		};
 
-		let event_queue = Arc::new(EventQueue::new(Arc::clone(&store), Arc::clone(&logger)));
-
 		let tx_metadata = TxMetadataStore::new(Arc::clone(&store)).await;
+
+		let event_queue =
+			Arc::new(EventQueue::new(Arc::clone(&store), tx_metadata.clone(), Arc::clone(&logger)));
 
 		// Cashu must init before LDK Node because CashuKvDatabase does
 		// synchronous SQLite reads that deadlock with LDK Node's background
@@ -795,6 +796,11 @@ impl Wallet {
 			transaction: Option<Transaction>,
 		}
 
+		// Multi-path payments are split into a trusted leg and a lightning leg. We merge the two
+		// legs, keyed by the surfaced payment id, into a single transaction with the combined amount
+		// and summed fees.
+		let mut mpp_payments: HashMap<PaymentId, MppMerge> = HashMap::new();
+
 		for payment in trusted_payments {
 			if let Some(tx_metadata) = tx_metadata.get(&PaymentId::Trusted(payment.id)) {
 				match &tx_metadata.ty {
@@ -858,6 +864,17 @@ impl Wallet {
 								payment.time_since_epoch
 							},
 						});
+					},
+					TxType::MppPayment { surface_id, total_amount_msat, ty, .. } => {
+						let entry = mpp_payments.entry(*surface_id).or_default();
+						entry.accumulate(
+							MppLegKind::Trusted,
+							*total_amount_msat,
+							payment.fee.milli_sats(),
+							payment.status,
+							*ty,
+							tx_metadata.time,
+						);
 					},
 					TxType::PendingRebalance { .. } => {
 						// Pending rebalances are not shown in the transaction list.
@@ -990,6 +1007,17 @@ impl Wallet {
 						payment_type: (&payment).into(),
 						time_since_epoch: tx_metadata.time,
 					}),
+					TxType::MppPayment { surface_id, total_amount_msat, ty: _, .. } => {
+						let entry = mpp_payments.entry(*surface_id).or_default();
+						entry.accumulate(
+							MppLegKind::Lightning,
+							*total_amount_msat,
+							fee.unwrap_or(Amount::ZERO).milli_sats(),
+							payment.status.into(),
+							(&payment).into(),
+							tx_metadata.time,
+						);
+					},
 					TxType::PendingRebalance { .. } => {
 						// Pending rebalances are not shown in the transaction list.
 						continue;
@@ -1051,6 +1079,10 @@ impl Wallet {
 				);
 				res.push(transaction);
 			}
+		}
+
+		for (surface_id, merge) in mpp_payments {
+			res.push(merge.into_transaction(surface_id));
 		}
 
 		res.sort_by_key(|e| e.time_since_epoch);
@@ -1199,6 +1231,7 @@ impl Wallet {
 
 		let mut last_trusted_err = None;
 		let mut last_lightning_err = None;
+		let mut last_mpp_err: Option<WalletError> = None;
 
 		let mut pay_trusted = async |method: PaymentMethod, ty: fn() -> PaymentType| {
 			if instructions.amount <= trusted_balance {
@@ -1371,7 +1404,30 @@ impl Wallet {
 			}
 		}
 
-		// TODO: Try to MPP the payment using both trusted and LN funds
+		// If neither wallet can cover the full amount on its own, try to split the payment across
+		// both using a multi-path payment. This is only possible for amount-bearing BOLT 11
+		// invoices and when the trusted wallet supports partial payments.
+		if self.inner.trusted.supports_partial_payments() {
+			for method in &methods {
+				if let PaymentMethod::LightningBolt11(invoice) = method {
+					match self
+						.try_mpp_bolt11(
+							invoice,
+							instructions.amount,
+							trusted_balance,
+							ln_balance.lightning,
+						)
+						.await
+					{
+						Ok(id) => return Ok(id),
+						Err(e) => {
+							log_debug!(self.inner.logger, "MPP payment attempt failed: {e:?}");
+							last_mpp_err = Some(e);
+						},
+					}
+				}
+			}
+		}
 
 		// Finally, try trusted on-chain first,
 		for method in methods.clone() {
@@ -1395,9 +1451,144 @@ impl Wallet {
 			}
 		}
 
-		Err(last_lightning_err.unwrap_or(
-			last_trusted_err.unwrap_or(WalletError::LdkNodeFailure(NodeError::InsufficientFunds)),
-		))
+		Err(last_lightning_err
+			.or(last_mpp_err)
+			.or(last_trusted_err)
+			.unwrap_or(WalletError::LdkNodeFailure(NodeError::InsufficientFunds)))
+	}
+
+	/// Attempts to pay `invoice` as a multi-path payment split across the trusted wallet and the
+	/// self-custody lightning wallet.
+	///
+	/// `amount` must equal the invoice's amount, which is declared as the MPP total. The trusted
+	/// wallet pays as much as its balance allows (always strictly less than the total) and the
+	/// lightning wallet pays the remainder over the same payment hash. Returns the lightning
+	/// payment's id on success.
+	async fn try_mpp_bolt11(
+		&self, invoice: &Bolt11Invoice, amount: Amount, trusted_balance: Amount,
+		ln_lightning_balance: Amount,
+	) -> Result<PaymentId, WalletError> {
+		// We can only declare the invoice amount as the MPP total, so MPP requires an
+		// amount-bearing invoice whose amount matches what we intend to pay.
+		let invoice_amount_msat = invoice
+			.amount_milli_satoshis()
+			.ok_or(WalletError::LdkNodeFailure(NodeError::InvalidInvoice))?;
+		if invoice_amount_msat != amount.milli_sats() {
+			return Err(WalletError::LdkNodeFailure(NodeError::InvalidAmount));
+		}
+
+		let method = PaymentMethod::LightningBolt11(invoice.clone());
+
+		// Avoid the trusted wallet's normal fee estimate here. Cashu obtains estimates by creating
+		// a non-MPP melt quote, and an active full-amount quote can block the partial MPP quote we
+		// need below. If fees make the trusted portion unaffordable, `pay_partial` will fail and the
+		// caller will continue through the normal fallback order.
+		let trusted_portion = trusted_balance;
+		if trusted_portion == Amount::ZERO || trusted_portion >= amount {
+			// Either the trusted wallet can't contribute, or it could cover the whole payment on
+			// its own (which should have been handled earlier); there is nothing to split.
+			return Err(WalletError::LdkNodeFailure(NodeError::InsufficientFunds));
+		}
+		let ln_portion = amount.saturating_sub(trusted_portion);
+
+		// Make sure the lightning wallet can cover its portion.
+		let ln_fee =
+			self.inner.ln_wallet.estimate_fee(&method, ln_portion).await.unwrap_or(Amount::ZERO);
+		if ln_fee.saturating_add(ln_portion) > ln_lightning_balance {
+			return Err(WalletError::LdkNodeFailure(NodeError::InsufficientFunds));
+		}
+
+		log_debug!(
+			self.inner.logger,
+			"Splitting {}msat payment via MPP: {}msat from trusted, {}msat from lightning",
+			amount.milli_sats(),
+			trusted_portion.milli_sats(),
+			ln_portion.milli_sats()
+		);
+
+		let payment_hash = invoice.payment_hash();
+		self.inner.event_queue.begin_mpp_setup(payment_hash).await;
+
+		// Pay the trusted portion first; the receiver will hold it until the lightning portion
+		// arrives to complete the MPP. We surface the combined payment under the trusted leg's id.
+		let trusted_id =
+			match self.inner.trusted.pay_partial(invoice.clone(), trusted_portion).await {
+				Ok(id) => id,
+				Err(e) => {
+					if let Err(queue_err) =
+						self.inner.event_queue.finish_mpp_setup(payment_hash).await
+					{
+						log_error!(
+							self.inner.logger,
+							"Failed to clear pending MPP events: {queue_err}"
+						);
+					}
+					return Err(e.into());
+				},
+			};
+		let surface_id = PaymentId::Trusted(trusted_id);
+
+		// Then pay the remainder from the lightning wallet over the same payment hash.
+		let ln_id = match self.inner.ln_wallet.pay_bolt11_underpaying(invoice, ln_portion) {
+			Ok(id) => id,
+			Err(e) => {
+				log_error!(self.inner.logger, "Failed to send lightning MPP portion: {e:?}");
+				// The trusted leg is already in flight but there will be no lightning leg to
+				// complete the MPP. Record it as a plain payment so its eventual (failed) terminal
+				// event surfaces normally rather than waiting on a sibling leg that never comes.
+				self.inner
+					.tx_metadata
+					.insert(
+						surface_id,
+						TxMetadata {
+							ty: TxType::Payment {
+								ty: PaymentType::OutgoingLightningBolt11 { payment_preimage: None },
+							},
+							time: SystemTime::now().duration_since(SystemTime::UNIX_EPOCH).unwrap(),
+						},
+					)
+					.await;
+				if let Err(queue_err) = self.inner.event_queue.finish_mpp_setup(payment_hash).await
+				{
+					log_error!(
+						self.inner.logger,
+						"Failed to replay pending MPP events: {queue_err}"
+					);
+				}
+				return Err(e.into());
+			},
+		};
+
+		// Record identical grouping metadata for both legs, keyed by their own ids. Each leg records
+		// its terminal result onto the entry surfaced under `surface_id`; whichever leg completes the
+		// payment yields the single combined event. The accumulated state is persisted, so the event
+		// is surfaced exactly once even across restarts.
+		let mpp_metadata = || TxMetadata {
+			ty: TxType::MppPayment {
+				surface_id,
+				lightning_leg: ln_id.0,
+				total_amount_msat: amount.milli_sats(),
+				ty: PaymentType::OutgoingLightningBolt11 { payment_preimage: None },
+				trusted_fee_msat: None,
+				lightning_fee_msat: None,
+				preimage: None,
+				failed: false,
+				finalized: false,
+			},
+			time: SystemTime::now().duration_since(SystemTime::UNIX_EPOCH).unwrap(),
+		};
+		self.inner.tx_metadata.insert(surface_id, mpp_metadata()).await;
+		self.inner.tx_metadata.upsert(PaymentId::SelfCustodial(ln_id.0), mpp_metadata()).await;
+		if let Err(queue_err) = self.inner.event_queue.finish_mpp_setup(payment_hash).await {
+			log_error!(self.inner.logger, "Failed to replay pending MPP events: {queue_err}");
+		}
+
+		let inner_ref = Arc::clone(&self.inner);
+		self.inner.runtime.spawn_cancellable_background_task(async move {
+			inner_ref.rebalancer.do_rebalance_if_needed().await;
+		});
+
+		Ok(surface_id)
 	}
 
 	/// Initiates closing all channels in the lightning wallet. The channel will not be closed

--- a/orange-sdk/src/lightning_wallet.rs
+++ b/orange-sdk/src/lightning_wallet.rs
@@ -373,6 +373,19 @@ impl LightningWallet {
 		}
 	}
 
+	/// Pays `amount` toward `invoice` as a single part of a multi-path payment (MPP), declaring the
+	/// invoice's own amount as the MPP total. The remainder is expected to be paid out of another
+	/// wallet over the same payment hash. This requires an amount-bearing invoice.
+	pub(crate) fn pay_bolt11_underpaying(
+		&self, invoice: &Bolt11Invoice, amount: Amount,
+	) -> Result<PaymentId, NodeError> {
+		self.inner.ldk_node.bolt11_payment().send_using_amount_underpaying(
+			invoice,
+			amount.milli_sats(),
+			None,
+		)
+	}
+
 	pub(crate) async fn splice_all_into_channel(&self) -> Result<UserChannelId, NodeError> {
 		// find existing channel to splice into
 		let channels = self.inner.ldk_node.list_channels();

--- a/orange-sdk/src/store.rs
+++ b/orange-sdk/src/store.rs
@@ -255,6 +255,143 @@ pub(crate) enum TxType {
 		ty: PaymentType,
 	},
 	PendingRebalance {},
+	/// A single leg of a multi-path payment that is split across the trusted and lightning
+	/// wallets. Both legs carry the same `surface_id`; the entry stored under that id additionally
+	/// accumulates each leg's terminal result so the two can be coalesced into a single event. The
+	/// accumulated fields are persisted, so the combined event is emitted exactly once even across
+	/// restarts and races between the two legs completing.
+	MppPayment {
+		/// The id under which the combined payment is surfaced to the user (the trusted leg id).
+		surface_id: PaymentId,
+		/// The lightning leg's payment id (equal to the BOLT 11 payment hash).
+		lightning_leg: [u8; 32],
+		/// The total amount, in msats, of the combined payment (i.e. the invoice amount).
+		total_amount_msat: u64,
+		/// The payment type of the combined transaction.
+		ty: PaymentType,
+		/// The trusted leg's fee, in msats, set once that leg succeeds.
+		trusted_fee_msat: Option<u64>,
+		/// The lightning leg's fee, in msats, set once that leg succeeds.
+		lightning_fee_msat: Option<u64>,
+		/// The shared payment preimage, set once either leg succeeds.
+		preimage: Option<[u8; 32]>,
+		/// Set if either leg failed.
+		failed: bool,
+		/// Set once the single combined terminal event has been surfaced.
+		finalized: bool,
+	},
+}
+
+/// The terminal outcome of a multi-path payment once both legs have resolved, returned by
+/// [`TxMetadataStore::record_mpp_leg`] to the caller that should surface the single combined event.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum MppOutcome {
+	/// Both legs succeeded.
+	Succeeded {
+		/// The BOLT 11 payment hash.
+		payment_hash: [u8; 32],
+		/// The shared payment preimage.
+		preimage: [u8; 32],
+		/// The combined fee, in msats, across both legs.
+		fee_msat: u64,
+	},
+	/// At least one leg failed.
+	Failed {
+		/// The BOLT 11 payment hash.
+		payment_hash: [u8; 32],
+	},
+}
+
+/// Which wallet a leg of a multi-path payment was paid out of.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum MppLegKind {
+	/// The leg paid by the trusted wallet (surfaced under the combined payment's id).
+	Trusted,
+	/// The leg paid by the self-custody lightning wallet.
+	Lightning,
+}
+
+/// The state of a single leg of a multi-path payment as reflected in the transaction list.
+#[derive(Debug, Clone, Copy)]
+struct MppLeg {
+	status: TxStatus,
+	fee_msat: u64,
+}
+
+/// Accumulates the two legs of a multi-path payment back into the single combined [`Transaction`]
+/// surfaced to the user. Each leg ([`TxType::MppPayment`]) is folded in with [`Self::accumulate`],
+/// tagged by which wallet paid it, and the result is built with [`Self::into_transaction`]. Both
+/// legs carry the same total amount, and their fees are summed. Tracking the trusted and lightning
+/// legs separately (rather than just counting them) lets us tell which leg is missing or failed
+/// when describing the payment's state.
+#[derive(Debug, Default)]
+pub(crate) struct MppMerge {
+	total_amount_msat: u64,
+	trusted: Option<MppLeg>,
+	lightning: Option<MppLeg>,
+	payment_type: Option<PaymentType>,
+	time: Option<Duration>,
+}
+
+impl MppMerge {
+	/// Folds the `leg` of the multi-path payment into the merge.
+	pub(crate) fn accumulate(
+		&mut self, leg: MppLegKind, total_amount_msat: u64, fee_msat: u64, status: TxStatus,
+		ty: PaymentType, time: Duration,
+	) {
+		self.total_amount_msat = total_amount_msat;
+		let slot = match leg {
+			MppLegKind::Trusted => &mut self.trusted,
+			MppLegKind::Lightning => &mut self.lightning,
+		};
+		*slot = Some(MppLeg { status, fee_msat });
+		// Prefer a payment type that carries the preimage (the lightning leg) for the
+		// combined transaction.
+		let ty_has_preimage = matches!(
+			ty,
+			PaymentType::OutgoingLightningBolt11 { payment_preimage: Some(_) }
+				| PaymentType::OutgoingLightningBolt12 { payment_preimage: Some(_) }
+		);
+		if self.payment_type.is_none() || ty_has_preimage {
+			self.payment_type = Some(ty);
+		}
+		self.time = Some(self.time.map_or(time, |t| t.min(time)));
+	}
+
+	/// The combined status of the payment: failed if either leg failed, completed only once both
+	/// legs have completed, and otherwise still pending.
+	pub(crate) fn status(&self) -> TxStatus {
+		let leg_status = |leg: Option<MppLeg>| leg.map(|l| l.status);
+		if [self.trusted, self.lightning].iter().any(|l| leg_status(*l) == Some(TxStatus::Failed)) {
+			TxStatus::Failed
+		} else if leg_status(self.trusted) == Some(TxStatus::Completed)
+			&& leg_status(self.lightning) == Some(TxStatus::Completed)
+		{
+			TxStatus::Completed
+		} else {
+			TxStatus::Pending
+		}
+	}
+
+	/// Builds the single combined transaction surfaced under `surface_id`, summing both legs' fees.
+	pub(crate) fn into_transaction(self, surface_id: PaymentId) -> Transaction {
+		let status = self.status();
+		let fee_msat = self
+			.trusted
+			.map_or(0, |l| l.fee_msat)
+			.saturating_add(self.lightning.map_or(0, |l| l.fee_msat));
+		Transaction {
+			id: surface_id,
+			status,
+			outbound: true,
+			amount: Some(Amount::from_milli_sats(self.total_amount_msat).expect("valid amount")),
+			fee: Some(Amount::from_milli_sats(fee_msat).expect("valid amount")),
+			payment_type: self
+				.payment_type
+				.unwrap_or(PaymentType::OutgoingLightningBolt11 { payment_preimage: None }),
+			time_since_epoch: self.time.unwrap_or_default(),
+		}
+	}
 }
 
 impl TxType {
@@ -281,6 +418,17 @@ impl_writeable_tlv_based_enum!(TxType,
 	(2, PaymentTriggeringTransferLightning) => { (0, ty, required), },
 	(3, Payment) => { (0, ty, required), },
 	(4, PendingRebalance) => {},
+	(5, MppPayment) => {
+		(0, surface_id, required),
+		(2, total_amount_msat, required),
+		(4, ty, required),
+		(6, lightning_leg, required),
+		(8, finalized, required),
+		(10, failed, required),
+		(12, trusted_fee_msat, option),
+		(14, lightning_fee_msat, option),
+		(16, preimage, option),
+	},
 );
 
 #[derive(Debug, Copy, Clone)]
@@ -296,6 +444,12 @@ impl_writeable_tlv_based!(TxMetadata, { (0, ty, required), (2, time, required) }
 pub(crate) struct TxMetadataStore {
 	tx_metadata: Arc<RwLock<HashMap<PaymentId, TxMetadata>>>,
 	store: Arc<dyn DynStore>,
+	/// Serializes the read-modify-persist sequence in [`Self::record_mpp_leg`]. Both legs of a
+	/// multi-path payment record their result onto the same surface entry; without this, two
+	/// concurrent legs could each encode a partial snapshot under the in-memory lock and then
+	/// persist them out of order, leaving a stale (non-finalized) entry on disk that would
+	/// re-emit the combined event after a restart.
+	mpp_record_lock: Arc<tokio::sync::Mutex<()>>,
 }
 
 impl TxMetadataStore {
@@ -315,7 +469,11 @@ impl TxMetadataStore {
 				.expect("Invalid data in transaction metadata storage");
 			tx_metadata.insert(key, data);
 		}
-		TxMetadataStore { store, tx_metadata: Arc::new(RwLock::new(tx_metadata)) }
+		TxMetadataStore {
+			store,
+			tx_metadata: Arc::new(RwLock::new(tx_metadata)),
+			mpp_record_lock: Arc::new(tokio::sync::Mutex::new(())),
+		}
 	}
 
 	pub fn read(&self) -> RwLockReadGuard<'_, HashMap<PaymentId, TxMetadata>> {
@@ -477,6 +635,100 @@ impl TxMetadataStore {
 			.expect("We do not allow writes to fail");
 		Ok(())
 	}
+
+	/// Records the terminal result of one leg of a multi-path payment, accumulating it onto the
+	/// shared entry surfaced to the user. `leg_id` is the leg's own payment id and `success` is
+	/// `Some((fee_msat, preimage))` if it succeeded or `None` if it failed.
+	///
+	/// Returns `Some` exactly once — for the call that completes the payment (both legs succeeded,
+	/// or the first leg failed) — with the combined [`MppOutcome`] the caller should surface as a
+	/// single event. Returns `None` while still waiting on the other leg, after the combined event
+	/// has already been produced, or if `leg_id` is not a multi-path payment leg.
+	///
+	/// All accumulated state is persisted, so the combined event is emitted exactly once even across
+	/// restarts and races between the two legs completing.
+	pub(crate) async fn record_mpp_leg(
+		&self, leg_id: PaymentId, success: Option<(u64, [u8; 32])>,
+	) -> Option<(PaymentId, MppOutcome)> {
+		// Hold this across the whole read-modify-persist so the two legs can't interleave: the
+		// snapshot we persist below must reflect the latest in-memory mutation, otherwise a stale
+		// (non-finalized) entry could be written last and re-emit the combined event on restart.
+		let _record_guard = self.mpp_record_lock.lock().await;
+
+		let (surface_id, key_str, ser, outcome) = {
+			let mut map = self.tx_metadata.write().unwrap();
+
+			// The leg's own entry tells us which combined payment it belongs to.
+			let surface_id = match map.get(&leg_id).map(|m| m.ty) {
+				Some(TxType::MppPayment { surface_id, .. }) => surface_id,
+				_ => return None,
+			};
+			// The combined payment is surfaced under the trusted leg's id.
+			let is_trusted_leg = leg_id == surface_id;
+
+			let outcome = {
+				let metadata = match map.get_mut(&surface_id) {
+					Some(metadata) => metadata,
+					None => return None,
+				};
+				let TxType::MppPayment {
+					lightning_leg,
+					trusted_fee_msat,
+					lightning_fee_msat,
+					preimage,
+					failed,
+					finalized,
+					..
+				} = &mut metadata.ty
+				else {
+					return None;
+				};
+				if *finalized {
+					return None;
+				}
+
+				match success {
+					Some((fee_msat, leg_preimage)) => {
+						if is_trusted_leg {
+							*trusted_fee_msat = Some(fee_msat);
+						} else {
+							*lightning_fee_msat = Some(fee_msat);
+						}
+						*preimage = Some(leg_preimage);
+					},
+					None => *failed = true,
+				}
+
+				let payment_hash = *lightning_leg;
+				if *failed {
+					*finalized = true;
+					Some(MppOutcome::Failed { payment_hash })
+				} else if let (Some(trusted_fee), Some(lightning_fee)) =
+					(*trusted_fee_msat, *lightning_fee_msat)
+				{
+					*finalized = true;
+					Some(MppOutcome::Succeeded {
+						payment_hash,
+						preimage: preimage.expect("set whenever a leg succeeds"),
+						fee_msat: trusted_fee.saturating_add(lightning_fee),
+					})
+				} else {
+					None
+				}
+			};
+
+			// We mutated the surface entry (recorded this leg), so persist it regardless of whether
+			// the payment is now complete.
+			let ser = map.get(&surface_id).expect("surface entry present").encode();
+			(surface_id, surface_id.to_string(), ser, outcome)
+		};
+
+		KVStore::write(self.store.as_ref(), STORE_PRIMARY_KEY, STORE_SECONDARY_KEY, &key_str, ser)
+			.await
+			.expect("We do not allow writes to fail");
+
+		outcome.map(|outcome| (surface_id, outcome))
+	}
 }
 
 const REBALANCE_ENABLED_KEY: &str = "rebalance_enabled";
@@ -536,7 +788,160 @@ pub(crate) async fn read_splice_outs(store: &dyn DynStore) -> Vec<PaymentDetails
 mod tests {
 	use super::*;
 	use ldk_node::bitcoin::hex::DisplayHex;
+	use ldk_node::io::sqlite_store::SqliteStore;
+	use std::path::PathBuf;
 	use std::str::FromStr;
+	use std::time::{SystemTime, UNIX_EPOCH};
+
+	fn temp_sqlite_store() -> (PathBuf, Arc<dyn DynStore>) {
+		let path = std::env::temp_dir().join(format!(
+			"orange-sdk-mpp-finalize-test-{}",
+			SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_nanos()
+		));
+		let store = SqliteStore::new(path.clone(), Some("orange.sqlite".to_string()), None)
+			.expect("sqlite store");
+		(path, Arc::new(store))
+	}
+
+	const TRUSTED_LEG: [u8; 32] = [7u8; 32];
+	const LIGHTNING_LEG: [u8; 32] = [9u8; 32];
+
+	fn surface_id() -> PaymentId {
+		PaymentId::Trusted(TRUSTED_LEG)
+	}
+	fn lightning_id() -> PaymentId {
+		PaymentId::SelfCustodial(LIGHTNING_LEG)
+	}
+
+	fn mpp_metadata() -> TxMetadata {
+		TxMetadata {
+			ty: TxType::MppPayment {
+				surface_id: surface_id(),
+				lightning_leg: LIGHTNING_LEG,
+				total_amount_msat: 200_000,
+				ty: PaymentType::OutgoingLightningBolt11 { payment_preimage: None },
+				trusted_fee_msat: None,
+				lightning_fee_msat: None,
+				preimage: None,
+				failed: false,
+				finalized: false,
+			},
+			time: Duration::from_secs(1),
+		}
+	}
+
+	// Both legs record their result onto the shared entry; the second to land yields the single
+	// combined outcome.
+	async fn insert_legs(tx_metadata: &TxMetadataStore) {
+		tx_metadata.insert(surface_id(), mpp_metadata()).await;
+		tx_metadata.insert(lightning_id(), mpp_metadata()).await;
+	}
+
+	#[tokio::test]
+	async fn record_mpp_leg_combines_both_legs_once() {
+		let (_path, store) = temp_sqlite_store();
+		let tx_metadata = TxMetadataStore::new(store).await;
+		insert_legs(&tx_metadata).await;
+
+		// First leg: still waiting on the other.
+		assert_eq!(tx_metadata.record_mpp_leg(surface_id(), Some((1_000, [1u8; 32]))).await, None);
+
+		// Second leg completes the payment: a single combined success with the summed fees.
+		assert_eq!(
+			tx_metadata.record_mpp_leg(lightning_id(), Some((2_000, [1u8; 32]))).await,
+			Some((
+				surface_id(),
+				MppOutcome::Succeeded {
+					payment_hash: LIGHTNING_LEG,
+					preimage: [1u8; 32],
+					fee_msat: 3_000,
+				}
+			))
+		);
+
+		// A replayed leg event (e.g. after a crash) does not produce a second event.
+		assert_eq!(tx_metadata.record_mpp_leg(surface_id(), Some((1_000, [1u8; 32]))).await, None);
+		assert_eq!(
+			tx_metadata.record_mpp_leg(lightning_id(), Some((2_000, [1u8; 32]))).await,
+			None
+		);
+	}
+
+	// The exactly-once guarantee must survive a crash/restart: the recorded legs and the finalized
+	// flag are persisted, so reloading the store from disk still suppresses a re-emit. We simulate a
+	// crash/restart by dropping the `TxMetadataStore` and rebuilding it from the same on-disk store.
+	#[tokio::test]
+	async fn record_mpp_leg_persists_across_restart() {
+		let path = std::env::temp_dir().join(format!(
+			"orange-sdk-mpp-record-test-{}",
+			SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_nanos()
+		));
+		let open = |path: PathBuf| -> Arc<dyn DynStore> {
+			Arc::new(
+				SqliteStore::new(path, Some("orange.sqlite".to_string()), None)
+					.expect("sqlite store"),
+			)
+		};
+
+		{
+			let tx_metadata = TxMetadataStore::new(open(path.clone())).await;
+			insert_legs(&tx_metadata).await;
+			assert_eq!(
+				tx_metadata.record_mpp_leg(surface_id(), Some((1_000, [1u8; 32]))).await,
+				None
+			);
+			assert!(
+				tx_metadata
+					.record_mpp_leg(lightning_id(), Some((2_000, [1u8; 32])))
+					.await
+					.is_some()
+			);
+		}
+
+		// Simulate a crash/restart: reload from the same on-disk store.
+		{
+			let tx_metadata = TxMetadataStore::new(open(path.clone())).await;
+			// Both the recorded legs and the finalized flag survived, so a replayed event after the
+			// restart does not surface a duplicate combined event.
+			assert_eq!(
+				tx_metadata.record_mpp_leg(lightning_id(), Some((2_000, [1u8; 32]))).await,
+				None
+			);
+		}
+	}
+
+	#[tokio::test]
+	async fn record_mpp_leg_surfaces_failure_and_guards_non_mpp() {
+		let (_path, store) = temp_sqlite_store();
+		let tx_metadata = TxMetadataStore::new(store).await;
+		insert_legs(&tx_metadata).await;
+
+		// A failed leg fails the whole payment immediately, exactly once.
+		assert_eq!(
+			tx_metadata.record_mpp_leg(surface_id(), None).await,
+			Some((surface_id(), MppOutcome::Failed { payment_hash: LIGHTNING_LEG }))
+		);
+		assert_eq!(
+			tx_metadata.record_mpp_leg(lightning_id(), Some((2_000, [1u8; 32]))).await,
+			None
+		);
+
+		// Unknown ids and non-MPP payments are never treated as MPP legs.
+		assert_eq!(tx_metadata.record_mpp_leg(PaymentId::Trusted([5u8; 32]), None).await, None);
+		let plain = PaymentId::Trusted([4u8; 32]);
+		tx_metadata
+			.insert(
+				plain,
+				TxMetadata {
+					ty: TxType::Payment {
+						ty: PaymentType::OutgoingLightningBolt11 { payment_preimage: None },
+					},
+					time: Duration::from_secs(1),
+				},
+			)
+			.await;
+		assert_eq!(tx_metadata.record_mpp_leg(plain, Some((1, [0u8; 32]))).await, None);
+	}
 
 	#[test]
 	fn test_payment_id_round_trip() {

--- a/orange-sdk/src/trusted_wallet/cashu/mod.rs
+++ b/orange-sdk/src/trusted_wallet/cashu/mod.rs
@@ -66,6 +66,7 @@ pub struct Cashu {
 	payment_success_flag: watch::Receiver<()>,
 	logger: Arc<Logger>,
 	supports_bolt12: Arc<std::sync::atomic::AtomicBool>,
+	supports_mpp: Arc<std::sync::atomic::AtomicBool>,
 	mint_quote_sender: mpsc::Sender<MintQuote>,
 	event_queue: Arc<EventQueue>,
 	tx_metadata: TxMetadataStore,
@@ -312,159 +313,45 @@ impl TrustedWalletInterface for Cashu {
 			// We'll use the quote ID as the payment identifier
 			let payment_id = Self::id_to_32_byte_array(&quote.id);
 
-			// Execute the melt in separate thread, do not block on it being successful/failed
-			let cashu_wallet = Arc::clone(&self.cashu_wallet);
-			let logger = Arc::clone(&self.logger);
-			let event_queue = Arc::clone(&self.event_queue);
-			let tx_metadata = self.tx_metadata.clone();
-			let quote_id = quote.id.clone();
-			let payment_success_sender = self.payment_success_sender.clone();
-			self.runtime.spawn_background_task(async move {
-				let mut metadata = HashMap::new();
-				if let Some(hash) = &payment_hash {
-					metadata.insert(PAYMENT_HASH_METADATA_KEY.to_string(), hash.to_string());
-				}
+			// Execute the melt in a background task; do not block on it succeeding/failing.
+			self.spawn_melt(quote.id.clone(), payment_id, payment_hash);
 
-				let melt_result = async {
-					let prepared = cashu_wallet.prepare_melt(&quote_id, metadata).await?;
-					prepared.confirm().await
-				}
-				.await;
-				match melt_result {
-					Ok(res) => {
-						match res.state() {
-							MeltQuoteState::Paid => {
-								log_info!(logger, "Successfully sent for quote: {quote_id}");
+			Ok(payment_id)
+		})
+	}
 
-								let payment_id = PaymentId::Trusted(payment_id);
-								let is_rebalance = {
-									let map = tx_metadata.read();
-									map.get(&payment_id).is_some_and(|m| m.ty.is_rebalance())
-								};
-								if is_rebalance {
-									// make sure we still send payment success
-									payment_success_sender.send(()).unwrap();
-									return;
-								}
+	fn supports_partial_payments(&self) -> bool {
+		// Partial MPP payments require the mint to advertise NUT-15 support for BOLT 11 in our unit.
+		self.supports_mpp.load(std::sync::atomic::Ordering::Relaxed)
+	}
 
-								let preimage: Option<PaymentPreimage> = match res.payment_proof() {
-									Some(str) => match FromHex::from_hex(str) {
-										Ok(b) => Some(PaymentPreimage(b)),
-										Err(e) => {
-											log_error!(
-												logger,
-												"Failed to decode preimage ({:?}) for quote {quote_id}: {e}",
-												res.payment_proof()
-											);
-											None
-										},
-									},
-									None => {
-										debug_assert!(
-											false,
-											"Melt succeeded but no preimage for quote: {quote_id}"
-										);
-										log_error!(
-											logger,
-											"Melt succeeded but no preimage for quote: {quote_id}"
-										);
-										None // Placeholder, should not happen
-									},
-								};
+	fn pay_partial(
+		&self, invoice: Bolt11Invoice, partial_amount: Amount,
+	) -> Pin<Box<dyn Future<Output = Result<[u8; 32], TrustedError>> + Send + '_>> {
+		Box::pin(async move {
+			if !self.supports_mpp.load(std::sync::atomic::Ordering::Relaxed) {
+				return Err(TrustedError::UnsupportedOperation(
+					"Cashu mint does not support partial (MPP) payments".to_owned(),
+				));
+			}
 
-								let hash = match payment_hash {
-									Some(hash) => hash,
-									None => {
-										match preimage {
-											Some(pre) => {
-												let hash = Sha256::hash(&pre.0);
-												PaymentHash(hash.to_byte_array())
-											},
-											None => {
-												log_error!(
-													logger,
-													"Melt succeeded but no payment hash or preimage for quote: {quote_id}"
-												);
-												PaymentHash([0u8; 32]) // Placeholder, should not happen
-											},
-										}
-									},
-								};
+			// An MPP melt declares the partial amount this mint should pay toward the invoice; the
+			// remainder is paid out of the lightning wallet over the same payment hash.
+			let melt_options = Some(MeltOptions::new_mpp(partial_amount.milli_sats()));
+			let payment_hash = Some(invoice.payment_hash());
 
-								let payment_preimage =
-									preimage.unwrap_or(PaymentPreimage([0u8; 32]));
+			let quote = self
+				.cashu_wallet
+				.melt_quote(CdkPaymentMethod::BOLT11, invoice.to_string(), melt_options, None)
+				.await
+				.map_err(|e| {
+					TrustedError::WalletOperationFailed(format!(
+						"Failed to create MPP melt quote: {e}"
+					))
+				})?;
 
-								if tx_metadata
-									.set_preimage(payment_id, payment_preimage.0)
-									.await
-									.is_err()
-								{
-									log_error!(
-										logger,
-										"Failed to set preimage for payment {payment_id:?}"
-									);
-								}
-
-								let fee_paid_sat: u64 = res.fee_paid().into();
-								let _ = event_queue
-									.add_event(Event::PaymentSuccessful {
-										payment_id,
-										payment_hash: hash,
-										payment_preimage,
-										fee_paid_msat: Some(fee_paid_sat * 1_000), // convert to msats
-									})
-									.await;
-
-								payment_success_sender.send(()).unwrap();
-							},
-							MeltQuoteState::Failed => {
-								log_error!(logger, "Melt failed for quote: {quote_id}");
-								let payment_id = PaymentId::Trusted(payment_id);
-								let is_rebalance = {
-									let map = tx_metadata.read();
-									map.get(&payment_id).is_some_and(|m| m.ty.is_rebalance())
-								};
-
-								if !is_rebalance {
-									let _ = event_queue
-										.add_event(Event::PaymentFailed {
-											payment_id,
-											payment_hash,
-											reason: None,
-										})
-										.await;
-								}
-							},
-							state => {
-								log_error!(
-									logger,
-									"Melt in unknown state {state} for quote: {quote_id}"
-								);
-								// todo should we watch for it to complete?
-							},
-						}
-					},
-					Err(e) => {
-						log_error!(logger, "Failed to melt quote {quote_id}: {e}");
-						let payment_id = PaymentId::Trusted(payment_id);
-						let is_rebalance = {
-							let map = tx_metadata.read();
-							map.get(&payment_id).is_some_and(|m| m.ty.is_rebalance())
-						};
-
-						if !is_rebalance {
-							let _ = event_queue
-								.add_event(Event::PaymentFailed {
-									payment_id,
-									payment_hash,
-									reason: None,
-								})
-								.await;
-						}
-					},
-				}
-			});
-
+			let payment_id = Self::id_to_32_byte_array(&quote.id);
+			self.spawn_melt(quote.id.clone(), payment_id, payment_hash);
 			Ok(payment_id)
 		})
 	}
@@ -586,13 +473,27 @@ impl Cashu {
 		);
 
 		let supports_bolt12 = Arc::new(std::sync::atomic::AtomicBool::new(false));
+		let supports_mpp = Arc::new(std::sync::atomic::AtomicBool::new(false));
 		{
 			let w = Arc::clone(&cashu_wallet);
-			let flag = Arc::clone(&supports_bolt12);
+			let bolt12_flag = Arc::clone(&supports_bolt12);
+			let mpp_flag = Arc::clone(&supports_mpp);
+			let unit = cashu_config.unit.clone();
 			runtime.spawn_cancellable_background_task(async move {
 				if let Some(info) = w.fetch_mint_info().await.ok().flatten() {
 					if info.nuts.nut04.supported_methods().contains(&&CdkPaymentMethod::BOLT12) {
-						flag.store(true, std::sync::atomic::Ordering::Relaxed);
+						bolt12_flag.store(true, std::sync::atomic::Ordering::Relaxed);
+					}
+					// NUT-15 advertises which (method, unit) pairs the mint will accept partial MPP
+					// melts for.
+					let mpp_supported = info
+						.nuts
+						.nut15
+						.methods
+						.iter()
+						.any(|m| m.method == CdkPaymentMethod::BOLT11 && m.unit == unit);
+					if mpp_supported {
+						mpp_flag.store(true, std::sync::atomic::Ordering::Relaxed);
 					}
 				}
 			});
@@ -742,6 +643,7 @@ impl Cashu {
 			payment_success_flag,
 			logger,
 			supports_bolt12,
+			supports_mpp,
 			mint_quote_sender,
 			event_queue,
 			tx_metadata,
@@ -765,6 +667,166 @@ impl Cashu {
 		let (xonly, _) = sk.public_key(&secp).x_only_public_key();
 		let hrp = Hrp::parse("npub").expect("valid hrp");
 		encode::<Bech32>(hrp, &xonly.serialize()).map_err(|e| format!("bech32 encode: {e}"))
+	}
+
+	/// Executes a previously-created melt quote in a background task, emitting a
+	/// [`PaymentSuccessful`] or [`PaymentFailed`] event when it completes. The payment is not
+	/// awaited; this only kicks off the melt.
+	///
+	/// [`PaymentSuccessful`]: crate::event::Event::PaymentSuccessful
+	/// [`PaymentFailed`]: crate::event::Event::PaymentFailed
+	fn spawn_melt(
+		&self, quote_id: String, payment_id: [u8; 32], payment_hash: Option<PaymentHash>,
+	) {
+		let cashu_wallet = Arc::clone(&self.cashu_wallet);
+		let logger = Arc::clone(&self.logger);
+		let event_queue = Arc::clone(&self.event_queue);
+		let tx_metadata = self.tx_metadata.clone();
+		let payment_success_sender = self.payment_success_sender.clone();
+		self.runtime.spawn_background_task(async move {
+			let mut metadata = HashMap::new();
+			if let Some(hash) = &payment_hash {
+				metadata.insert(PAYMENT_HASH_METADATA_KEY.to_string(), hash.to_string());
+			}
+
+			let melt_result = async {
+				let prepared = cashu_wallet.prepare_melt(&quote_id, metadata).await?;
+				prepared.confirm().await
+			}
+			.await;
+			match melt_result {
+				Ok(res) => {
+					match res.state() {
+						MeltQuoteState::Paid => {
+							log_info!(logger, "Successfully sent for quote: {quote_id}");
+
+							let payment_id = PaymentId::Trusted(payment_id);
+							let is_rebalance = {
+								let map = tx_metadata.read();
+								map.get(&payment_id).is_some_and(|m| m.ty.is_rebalance())
+							};
+							if is_rebalance {
+								// make sure we still send payment success
+								payment_success_sender.send(()).unwrap();
+								return;
+							}
+
+							let preimage: Option<PaymentPreimage> = match res.payment_proof() {
+								Some(str) => match FromHex::from_hex(str) {
+									Ok(b) => Some(PaymentPreimage(b)),
+									Err(e) => {
+										log_error!(
+											logger,
+											"Failed to decode preimage ({:?}) for quote {quote_id}: {e}",
+											res.payment_proof()
+										);
+										None
+									},
+								},
+								None => {
+									debug_assert!(
+										false,
+										"Melt succeeded but no preimage for quote: {quote_id}"
+									);
+									log_error!(
+										logger,
+										"Melt succeeded but no preimage for quote: {quote_id}"
+									);
+									None // Placeholder, should not happen
+								},
+							};
+
+							let hash = match payment_hash {
+								Some(hash) => hash,
+								None => {
+									match preimage {
+										Some(pre) => {
+											let hash = Sha256::hash(&pre.0);
+											PaymentHash(hash.to_byte_array())
+										},
+										None => {
+											log_error!(
+												logger,
+												"Melt succeeded but no payment hash or preimage for quote: {quote_id}"
+											);
+											PaymentHash([0u8; 32]) // Placeholder, should not happen
+										},
+									}
+								},
+							};
+
+							let payment_preimage = preimage.unwrap_or(PaymentPreimage([0u8; 32]));
+
+							if tx_metadata
+								.set_preimage(payment_id, payment_preimage.0)
+								.await
+								.is_err()
+							{
+								log_error!(
+									logger,
+									"Failed to set preimage for payment {payment_id:?}"
+								);
+							}
+
+							let fee_paid_sat: u64 = res.fee_paid().into();
+							let _ = event_queue
+								.add_event(Event::PaymentSuccessful {
+									payment_id,
+									payment_hash: hash,
+									payment_preimage,
+									fee_paid_msat: Some(fee_paid_sat * 1_000), // convert to msats
+								})
+								.await;
+
+							payment_success_sender.send(()).unwrap();
+						},
+						MeltQuoteState::Failed => {
+							log_error!(logger, "Melt failed for quote: {quote_id}");
+							let payment_id = PaymentId::Trusted(payment_id);
+							let is_rebalance = {
+								let map = tx_metadata.read();
+								map.get(&payment_id).is_some_and(|m| m.ty.is_rebalance())
+							};
+
+							if !is_rebalance {
+								let _ = event_queue
+									.add_event(Event::PaymentFailed {
+										payment_id,
+										payment_hash,
+										reason: None,
+									})
+									.await;
+							}
+						},
+						state => {
+							log_error!(
+								logger,
+								"Melt in unknown state {state} for quote: {quote_id}"
+							);
+							// todo should we watch for it to complete?
+						},
+					}
+				},
+				Err(e) => {
+					log_error!(logger, "Failed to melt quote {quote_id}: {e}");
+					let payment_id = PaymentId::Trusted(payment_id);
+					let is_rebalance = {
+						let map = tx_metadata.read();
+						map.get(&payment_id).is_some_and(|m| m.ty.is_rebalance())
+					};
+
+					if !is_rebalance {
+						let _ = event_queue
+							.add_event(Event::PaymentFailed {
+								payment_id,
+								payment_hash,
+								reason: None,
+							})
+							.await;
+					}
+				},
+			}
+		});
 	}
 
 	/// Convert an ID string to a 32-byte array

--- a/orange-sdk/src/trusted_wallet/dummy.rs
+++ b/orange-sdk/src/trusted_wallet/dummy.rs
@@ -452,6 +452,46 @@ impl TrustedWalletInterface for DummyTrustedWallet {
 		})
 	}
 
+	fn supports_partial_payments(&self) -> bool {
+		// The dummy wallet is backed by an LDK node, which supports underpaying MPP HTLCs.
+		true
+	}
+
+	fn pay_partial(
+		&self, invoice: Bolt11Invoice, partial_amount: Amount,
+	) -> Pin<Box<dyn Future<Output = Result<[u8; 32], TrustedError>> + Send + '_>> {
+		Box::pin(async move {
+			let id = self
+				.ldk_node
+				.bolt11_payment()
+				.send_using_amount_underpaying(&invoice, partial_amount.milli_sats(), None)
+				.map_err(|e| TrustedError::WalletOperationFailed(e.to_string()))?
+				.0;
+			let id = mangle_payment_id(id);
+
+			// subtract our portion from our balance
+			self.current_bal_msats.fetch_sub(partial_amount.milli_sats(), Ordering::SeqCst);
+
+			let now = std::time::SystemTime::now()
+				.duration_since(std::time::UNIX_EPOCH)
+				.unwrap_or_default()
+				.as_secs();
+
+			// add to payments
+			let mut list = self.payments.write().await;
+			list.push(Payment {
+				id,
+				amount: partial_amount,
+				fee: Amount::ZERO,
+				status: TxStatus::Pending,
+				outbound: true,
+				time_since_epoch: Duration::from_secs(now),
+			});
+
+			Ok(id)
+		})
+	}
+
 	fn await_payment_success(
 		&self, payment_hash: [u8; 32],
 	) -> Pin<Box<dyn Future<Output = Option<ReceivedLightningPayment>> + Send + '_>> {

--- a/orange-sdk/src/trusted_wallet/mod.rs
+++ b/orange-sdk/src/trusted_wallet/mod.rs
@@ -83,6 +83,38 @@ pub trait TrustedWalletInterface: Send + Sync + private::Sealed {
 		&self, method: PaymentMethod, amount: Amount,
 	) -> Pin<Box<dyn Future<Output = Result<[u8; 32], TrustedError>> + Send + '_>>;
 
+	/// Returns whether this wallet supports making partial (multi-path) payments toward a
+	/// BOLT 11 invoice.
+	///
+	/// When `true`, [`pay_partial`] may be used to pay only a portion of an invoice's amount,
+	/// with the remainder paid out of another wallet (e.g. the self-custody lightning wallet)
+	/// over the same payment hash.
+	///
+	/// [`pay_partial`]: Self::pay_partial
+	fn supports_partial_payments(&self) -> bool;
+
+	/// Pays `partial_amount` toward the given BOLT 11 `invoice` as a single part of a
+	/// multi-path payment (MPP).
+	///
+	/// The invoice's own amount is declared as the MPP total, so the remaining
+	/// `invoice amount - partial_amount` is expected to be paid out of another wallet over the
+	/// same payment hash for the receiver to claim the payment. This requires an amount-bearing
+	/// invoice; paying toward a zero-amount invoice is not supported.
+	///
+	/// As with [`pay`], this only initiates the payment and returns its payment ID, later
+	/// emitting a [`PaymentSuccessful`] or [`PaymentFailed`] event.
+	///
+	/// Implementations that do not support partial payments (see [`supports_partial_payments`])
+	/// should return [`TrustedError::UnsupportedOperation`].
+	///
+	/// [`pay`]: Self::pay
+	/// [`supports_partial_payments`]: Self::supports_partial_payments
+	/// [`PaymentSuccessful`]: `crate::event::Event::PaymentSuccessful`
+	/// [`PaymentFailed`]: `crate::event::Event::PaymentFailed`
+	fn pay_partial(
+		&self, invoice: Bolt11Invoice, partial_amount: Amount,
+	) -> Pin<Box<dyn Future<Output = Result<[u8; 32], TrustedError>> + Send + '_>>;
+
 	/// Waits for a payment with the given payment hash to succeed.
 	/// Returns the `ReceivedLightningPayment` if successful, or `None` if it fails or times out.
 	fn await_payment_success(

--- a/orange-sdk/src/trusted_wallet/spark/mod.rs
+++ b/orange-sdk/src/trusted_wallet/spark/mod.rs
@@ -249,6 +249,22 @@ impl TrustedWalletInterface for Spark {
 		})
 	}
 
+	fn supports_partial_payments(&self) -> bool {
+		// Spark pays the full invoice through the Spark service, so partial MPP payments are not
+		// supported.
+		false
+	}
+
+	fn pay_partial(
+		&self, _invoice: Bolt11Invoice, _partial_amount: Amount,
+	) -> Pin<Box<dyn Future<Output = Result<[u8; 32], TrustedError>> + Send + '_>> {
+		Box::pin(async move {
+			Err(TrustedError::UnsupportedOperation(
+				"Spark wallet does not support partial payments".to_owned(),
+			))
+		})
+	}
+
 	fn await_payment_success(
 		&self, payment_hash: [u8; 32],
 	) -> Pin<Box<dyn Future<Output = Option<ReceivedLightningPayment>> + Send + '_>> {

--- a/orange-sdk/tests/integration_tests.rs
+++ b/orange-sdk/tests/integration_tests.rs
@@ -233,6 +233,147 @@ async fn test_pay_from_trusted() {
 
 #[tokio::test(flavor = "multi_thread")]
 #[test_log::test]
+#[cfg_attr(
+	feature = "_cashu-tests",
+	ignore = "CDK's test mint/payment processor does not support partial MPP melts"
+)]
+async fn test_pay_mpp_trusted_and_lightning() {
+	test_utils::run_test(|params| async move {
+		let wallet = Arc::clone(&params.wallet);
+		let bitcoind = Arc::clone(&params.bitcoind);
+		let third_party = Arc::clone(&params.third_party);
+		let electrsd = Arc::clone(&params.electrsd);
+		let lsp = Arc::clone(&params.lsp);
+		let desc = Bolt11InvoiceDescription::Direct(Description::empty());
+
+		// Fund the trusted wallet with 100 sats. This must happen before we have a channel: once
+		// inbound liquidity exists, small receives are routed to the lightning wallet instead.
+		let trusted_amt = Amount::from_sats(100).unwrap();
+		let uri = wallet.get_single_use_receive_uri(Some(trusted_amt)).await.unwrap();
+		assert!(uri.from_trusted);
+		third_party.bolt11_payment().send(&uri.invoice, None).unwrap();
+		test_utils::wait_for_condition("trusted balance funded", || async {
+			wallet.get_balance().await.unwrap().trusted == trusted_amt
+		})
+		.await;
+		assert!(matches!(wait_next_event(&wallet).await, Event::PaymentReceived { .. }));
+
+		// Open a lightning channel.
+		open_channel_from_lsp(&wallet, Arc::clone(&third_party)).await;
+		generate_blocks(&bitcoind, &electrsd, 6).await;
+		test_utils::wait_for_condition("wallet sync after channel open", || async {
+			wallet.channels().iter().any(|c| c.confirmations.is_some_and(|n| n > 0) && c.is_usable)
+		})
+		.await;
+
+		// The channel leaves us with a large spendable lightning balance, so on its own lightning
+		// could cover the 200 sat payment below (and the trusted wallet alone cannot). Drain the
+		// lightning balance down to ~150 sats so that neither balance suffices alone, forcing an
+		// MPP split. We drain by paying the LSP directly so we don't consume the LSP's outbound
+		// liquidity toward the third party, which the MPP payment still needs.
+		let sendable =
+			wallet.channels().iter().find(|c| c.is_usable).unwrap().next_outbound_htlc_limit_msat;
+		let drain = lsp.bolt11_payment().receive(sendable - 150_000, &desc, 300).unwrap();
+		let drain_info = PaymentInfo::build(
+			wallet.parse_payment_instructions(&drain.to_string()).await.unwrap(),
+			None,
+		)
+		.unwrap();
+		wallet.pay(&drain_info).await.unwrap();
+		assert!(matches!(wait_next_event(&wallet).await, Event::PaymentSuccessful { .. }));
+		test_utils::wait_for_condition("lightning balance drained below 200 sats", || async {
+			wallet
+				.channels()
+				.iter()
+				.find(|c| c.is_usable)
+				.is_some_and(|c| c.next_outbound_htlc_limit_msat < 200_000)
+		})
+		.await;
+
+		// Pay the 200 sat invoice: it must be split as 100 sats from trusted + 100 sats from LN.
+		let pay_amt = Amount::from_sats(200).unwrap();
+		let invoice =
+			third_party.bolt11_payment().receive(pay_amt.milli_sats(), &desc, 300).unwrap();
+		let info = PaymentInfo::build(
+			wallet.parse_payment_instructions(&invoice.to_string()).await.unwrap(),
+			Some(pay_amt),
+		)
+		.unwrap();
+		wallet.pay(&info).await.unwrap();
+
+		// Even though the payment was split across two legs, the user should see exactly one
+		// combined success event over the invoice's payment hash. Its fee is the sum of both legs'
+		// fees.
+		let combined_fee_msat = match wait_next_event(&wallet).await {
+			Event::PaymentSuccessful { payment_hash, fee_paid_msat, .. } => {
+				assert_eq!(payment_hash, invoice.payment_hash());
+				fee_paid_msat.expect("combined MPP payment should report a fee")
+			},
+			e => panic!("Expected a single combined PaymentSuccessful event, got {e:?}"),
+		};
+		// No per-leg event should leak through; the combined event is the only one.
+		assert_eq!(wallet.next_event(), None, "MPP must surface a single success event");
+
+		// The third party received the full 200 sats (the aggregated MPP parts), and the trusted
+		// wallet was fully drained — so the remaining 100 sats must have come from lightning.
+		test_utils::wait_for_condition("third party received full amount", || {
+			let tp = Arc::clone(&third_party);
+			async move {
+				tp.list_payments().iter().any(|p| {
+					p.direction == PaymentDirection::Inbound
+						&& p.status == PaymentStatus::Succeeded
+						&& p.amount_msat == Some(pay_amt.milli_sats())
+				})
+			}
+		})
+		.await;
+		test_utils::wait_for_condition("trusted balance fully spent", || async {
+			wallet.get_balance().await.unwrap().trusted == Amount::ZERO
+		})
+		.await;
+
+		// The split payment is deduplicated into a single transaction with the full amount, the
+		// summed fee (matching the combined event), and the lightning preimage. The individual
+		// 100 sat legs must not appear on their own.
+		let txs = wallet.list_transactions().await.unwrap();
+		let mpp_txs: Vec<_> =
+			txs.iter().filter(|t| t.outbound && t.amount == Some(pay_amt)).collect();
+		assert_eq!(
+			mpp_txs.len(),
+			1,
+			"the MPP payment should appear as exactly one transaction, got {mpp_txs:?}"
+		);
+		let mpp_tx = mpp_txs[0];
+		assert_eq!(mpp_tx.status, TxStatus::Completed);
+		assert_eq!(
+			mpp_tx.amount,
+			Some(pay_amt),
+			"combined amount should be the full payment amount"
+		);
+		assert_eq!(
+			mpp_tx.fee.map(|f| f.milli_sats()),
+			Some(combined_fee_msat),
+			"combined transaction fee should match the combined event fee"
+		);
+		assert!(
+			matches!(
+				mpp_tx.payment_type,
+				PaymentType::OutgoingLightningBolt11 { payment_preimage: Some(_) }
+			),
+			"combined transaction should carry the lightning preimage, got {:?}",
+			mpp_tx.payment_type
+		);
+		let leg_amt = Amount::from_sats(100).unwrap();
+		assert!(
+			!txs.iter().any(|t| t.outbound && t.amount == Some(leg_amt)),
+			"individual MPP legs must not appear as their own transactions"
+		);
+	})
+	.await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[test_log::test]
 async fn test_sweep_to_ln() {
 	test_utils::run_test(|params| async move {
 		let wallet = Arc::clone(&params.wallet);


### PR DESCRIPTION
When neither the trusted wallet nor the lightning wallet can cover a payment on its own, split it across both as a multi-path payment rather than failing over to on-chain.

Not every trusted backend can contribute a partial MPP HTLC, so the TrustedWalletInterface gains a supports_partial_payments flag and a pay_partial method.