### PR TITLE
Fall back to p2p gossip on signet when no RGS URL is configured

### DIFF
--- a/orange-sdk/src/lightning_wallet.rs
+++ b/orange-sdk/src/lightning_wallet.rs
@@ -92,7 +92,18 @@ impl LightningWallet {
 						);
 					},
 					Network::Testnet4 => {},
-					Network::Signet => {},
+					// No public RGS server exists for arbitrary signet networks, and
+					// small signet deployments (an LSP + a mint + phones) often never
+					// reach any public graph at all — so with no gossip source the
+					// wallet can only pay route-hinted invoices; anything from a node
+					// with an announced channel fails with RouteNotFound before an
+					// HTLC is even dispatched. P2P gossip from the wallet's own peers
+					// (its LSP) teaches it exactly the local topology it needs, and
+					// signet graphs are small enough that sync cost is negligible.
+					// An explicitly configured rgs_url still takes precedence above.
+					Network::Signet => {
+						builder.set_gossip_source_p2p();
+					},
 					Network::Regtest => {
 						// We don't want to run an RGS server in tests so just enable p2p gossip
 						builder.set_gossip_source_p2p();


### PR DESCRIPTION
Fixes #86.

On signet with no `rgs_url` configured, the gossip-source match falls through to an empty arm, leaving the wallet with no network graph at all — it can only pay invoices whose route hints bridge from its own LSP channels, and anything from a node with an announced channel fails instantly with `RouteNotFound`.

This falls back to `set_gossip_source_p2p()` on signet, matching the existing regtest behavior. The wallet's peers are exactly its LSP (and whatever the LSP talks to), so p2p gossip teaches it precisely the local topology it needs; signet graphs are small enough that sync cost is negligible. An explicitly configured `rgs_url` still takes precedence.

Why not RGS: no public RGS server exists for arbitrary signets, and even on Mutinynet a small LSP+mint deployment may never reach the public graph — we verified this empirically before proposing the p2p route: opened an announced bridge channel from our mint to Mutinynet's best-connected public node, watched the first-party channel get indexed within the hour, and watched our third-party mint↔LSP announcement never propagate over 15+ hours (funding UTXO unspent, valid signatures — the relaying node simply doesn't forward leaf-peer third-party gossip). Details and timed on-device repro in #86 and the linked downstream issue.
