### PR TITLE
Don't panic when a same-mint melt settles without a preimage

### DIFF
--- a/orange-sdk/src/trusted_wallet/cashu/mod.rs
+++ b/orange-sdk/src/trusted_wallet/cashu/mod.rs
@@ -730,15 +730,17 @@ impl Cashu {
 									},
 								},
 								None => {
-									debug_assert!(
-										false,
-										"Melt succeeded but no preimage for quote: {quote_id}"
-									);
-									log_error!(
+									// Expected for same-mint payments: when the melt's
+									// bolt11 destination is a mint quote on this same
+									// mint, cdk-mintd settles internally — no Lightning
+									// payment occurs, so there is no preimage to return.
+									// The success path below already tolerates None
+									// (hash falls back to the invoice payment_hash).
+									log_info!(
 										logger,
-										"Melt succeeded but no preimage for quote: {quote_id}"
+										"Melt for quote {quote_id} settled without a preimage (internal/same-mint settlement)"
 									);
-									None // Placeholder, should not happen
+									None
 								},
 							};
 


### PR DESCRIPTION
Fixes #91. cdk-mintd settles same-mint payments internally (no Lightning payment → no `payment_proof`), so the melt-success `None`-preimage arm is a legitimate, reachable case — but it carries a `debug_assert!(false)` that panics every debug build the moment two wallets sharing a mint pay each other (full repro in #91; hits us on every trusted→trusted transfer between staging test wallets).

The success path already handles `None` (event hash falls back to the invoice `payment_hash`, which is always present for these melts), so the fix is just: stop asserting, log the expected case at info. `cargo test -p orange-sdk --lib` 17/17.